### PR TITLE
Wire up new release tag mappings.

### DIFF
--- a/tools/src/scie_pants/log.py
+++ b/tools/src/scie_pants/log.py
@@ -1,23 +1,59 @@
 # Copyright 2022 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from textwrap import dedent
 from typing import NoReturn
 
 from colors import green, red, yellow
 
 
-def log(message: str) -> None:
+def _log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
 def info(message: str) -> None:
-    log(green(message))
+    logging.info(message)
+    _log(green(message))
 
 
 def warn(message: str) -> None:
-    log(yellow(message))
+    logging.warning(message)
+    _log(yellow(message))
 
 
 def fatal(message: str) -> NoReturn:
+    logging.critical(message)
     sys.exit(red(message))
+
+
+def exception(message: str, exc_info=None) -> NoReturn:
+    logging.exception(message, exc_info=exc_info)
+    sys.exit(red(message))
+
+
+def init_logging(install_log: Path):
+    logging.root.setLevel(level=logging.DEBUG)
+
+    install_log.parent.mkdir(parents=True, exist_ok=True)
+    # This gets us ~5MB of logs max per version of the scie-jump (since we're writing these under
+    # the scie.bindings dir which is keyed to our lift manifest hash).
+    debug_handler = RotatingFileHandler(filename=install_log, maxBytes=1_000_000, backupCount=4)
+    debug_handler.setFormatter(
+        logging.Formatter(fmt="{asctime} {levelname}] {name}: {message}", style="{")
+    )
+    logging.root.addHandler(debug_handler)
+
+    sys.excepthook = lambda exc_type, exc, tb: exception(
+        dedent(
+            f"""\
+            Install failed: {exc}
+            More information can be found in the installation log:
+            {install_log}
+            """
+        ),
+        exc_info=(exc_type, exc, tb),
+    )


### PR DESCRIPTION
This gets us only using the GitHub rate-limited API in the most dire circumstances.

Fixes #6