### PR TITLE
Harden scie-pants against `PEX_*` env vars.

### DIFF
--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -120,6 +120,7 @@
           "bootstrap-tools": {
             "description": "Introspection tools for the Pants bootstrap process.",
             "env": {
+              "PEX_.*": null,
               "=PEX_ROOT": "{scie.bindings}/pex_root",
               "=PEX_PYTHON_PATH": "{scie.files.{scie.env.PYTHON}-{scie.platform}}/python/bin/{scie.env.PYTHON}"
             },
@@ -145,6 +146,7 @@
           "install": {
             "description": "Installs a hermetic Pants environment from PyPI or binaries.pantsbuild.org with optional debug support.",
             "env": {
+              "PEX_.*": null,
               "=PEX_ROOT": "{scie.bindings}/pex_root",
               "=PEX_PYTHON_PATH": "{scie.files.{scie.env.PYTHON}-{scie.platform}}/python/bin/{scie.env.PYTHON}"
             },

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -21,7 +21,7 @@ use url::Url;
 const BINARY: &str = "scie-pants";
 
 const PTEX_TAG: &str = "v0.6.0";
-const SCIE_JUMP_TAG: &str = "v0.6.0";
+const SCIE_JUMP_TAG: &str = "v0.7.0";
 
 const CARGO: &str = env!("CARGO");
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
@@ -635,7 +635,9 @@ fn test(
     ) {
         integration_test!("Linting, testing and packaging the tools codebase");
         execute(
-            Command::new(scie_pants_scie).args(["fmt", "lint", "check", "test", "package", "::"]),
+            Command::new(scie_pants_scie)
+                .args(["fmt", "lint", "check", "test", "package", "::"])
+                .env("PEX_SCRIPT", "Does not exist!"),
         )?;
 
         integration_test!(


### PR DESCRIPTION
This pre-emptively retro-avoids this issue the `./pants` script encountered:
  https://github.com/pantsbuild/setup/issues/105

Fixes #3