### PR TITLE
Add self-update capability to scie-pants.

### DIFF
--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -152,7 +152,9 @@
               "--scie",
               "{scie}",
               "--current-version",
-              "{scie.bindings.scie-pants-info:VERSION}"
+              "{scie.bindings.scie-pants-info:VERSION}",
+              "--github-api-bearer-token",
+              "{scie.env.PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN}"
             ]
           }
         },

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -132,6 +132,28 @@
               "--pants-version",
               "{scie.env.PANTS_VERSION}"
             ]
+          },
+          "update": {
+            "description": "Update scie-pants.",
+            "env": {
+              "=PEX_ROOT": "{scie.bindings}/pex_root",
+              "=PEX_PYTHON_PATH": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9"
+            },
+            "exe": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9",
+            "args": [
+              "{tools.pex}",
+              "update-scie-pants",
+              "--ptex-path",
+              "{ptex}",
+              "--platform",
+              "{scie.platform}",
+              "--base-dir",
+              "{scie.bindings}",
+              "--scie",
+              "{scie}",
+              "--current-version",
+              "{scie.bindings.scie-pants-info:VERSION}"
+            ]
           }
         },
         "bindings": {
@@ -140,6 +162,22 @@
             "exe": "{ptex}",
             "args": [
               "{scie.lift}"
+            ]
+          },
+          "scie-pants-info": {
+            "description": "Records information about the current scie-pants binary.",
+            "env": {
+              "=PEX_ROOT": "{scie.bindings}/pex_root",
+              "=PEX_PYTHON_PATH": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9"
+            },
+            "exe": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9",
+            "args": [
+              "{tools.pex}",
+              "record-scie-pants-info",
+              "--base-dir",
+              "{scie.bindings}",
+              "--scie",
+              "{scie}"
             ]
           },
           "install": {

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -670,7 +670,6 @@ fn test(
                 .args(["bootstrap-cache-key"]),
         )?;
 
-        // Before --python-repos-repos deprecation warning for --python-repos-find-links alternative.
         integration_test!(
             "Verifying --python-repos-repos is used prior to Pants 2.13 (no warnings should be \
             issued by Pants)"
@@ -711,6 +710,13 @@ fn test(
         }
         execute(&mut command)?;
     }
+
+    // TODO(John Sirois): When more than release becomes available, do a downgrade here to an older
+    // release as the last test.
+    integration_test!("Verifying self update works");
+    // N.B.: There should never be a newer release in CI; so this should always gracefully noop
+    // noting no newer release was available.
+    execute(Command::new(scie_pants_scie).env("SCIE_BOOT", "update"))?;
 
     Ok(())
 }

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -713,8 +713,8 @@ fn test(
         execute(&mut command)?;
     }
 
-    // TODO(John Sirois): When more than release becomes available, do a downgrade here to an older
-    // release as the last test.
+    // TODO(John Sirois): When more than one release becomes available, do a downgrade here to an
+    // older release as the last test.
     integration_test!("Verifying self update works");
     // N.B.: There should never be a newer release in CI; so this should always gracefully noop
     // noting no newer release was available.

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,17 @@ impl<T> OrExit<T> for Result<T> {
 fn main() {
     env_logger::init();
     let _timer = timer!(Level::Debug; "MAIN");
+
+    // N.B.: The bogus version of `report` is used to signal scie-pants should report version
+    // information for the update tool to use in determining if there are newer versions of
+    // scie-pants available.
+    if let Ok(value) = env::var("PANTS_BOOTSTRAP_VERSION") {
+        if "report" == value.as_str() {
+            println!(env!("CARGO_PKG_VERSION"));
+            std::process::exit(0);
+        }
+    }
+
     let pants_process = get_pants_process().or_exit();
     trace!("Launching: {pants_process:#?}");
     let exit_code = pants_process.exec().or_exit();

--- a/tools/src/scie_pants.dist-info/entry_points.txt
+++ b/tools/src/scie_pants.dist-info/entry_points.txt
@@ -1,3 +1,5 @@
 [console_scripts]
 bootstrap-tools = scie_pants.bootstrap_tools:main
 install-pants = scie_pants.install_pants:main
+update-scie-pants = scie_pants.update_scie_pants:main
+record-scie-pants-info = scie_pants.record_scie_pants_info:main

--- a/tools/src/scie_pants/log.py
+++ b/tools/src/scie_pants/log.py
@@ -35,13 +35,15 @@ def exception(message: str, exc_info=None) -> NoReturn:
     sys.exit(red(message))
 
 
-def init_logging(install_log: Path):
+def init_logging(base_dir: Path, log_name: str):
     logging.root.setLevel(level=logging.DEBUG)
 
-    install_log.parent.mkdir(parents=True, exist_ok=True)
+    log_file = base_dir / "logs" / f"{log_name}.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
     # This gets us ~5MB of logs max per version of the scie-jump (since we're writing these under
     # the scie.bindings dir which is keyed to our lift manifest hash).
-    debug_handler = RotatingFileHandler(filename=install_log, maxBytes=1_000_000, backupCount=4)
+    debug_handler = RotatingFileHandler(filename=log_file, maxBytes=1_000_000, backupCount=4)
     debug_handler.setFormatter(
         logging.Formatter(fmt="{asctime} {levelname}] {name}: {message}", style="{")
     )
@@ -52,7 +54,7 @@ def init_logging(install_log: Path):
             f"""\
             Install failed: {exc}
             More information can be found in the installation log:
-            {install_log}
+            {log_file}
             """
         ),
         exc_info=(exc_type, exc, tb),

--- a/tools/src/scie_pants/log.py
+++ b/tools/src/scie_pants/log.py
@@ -53,8 +53,7 @@ def init_logging(base_dir: Path, log_name: str):
         dedent(
             f"""\
             Install failed: {exc}
-            More information can be found in the installation log:
-            {log_file}
+            More information can be found in the log at: {log_file}
             """
         ),
         exc_info=(exc_type, exc, tb),

--- a/tools/src/scie_pants/ptex.py
+++ b/tools/src/scie_pants/ptex.py
@@ -39,7 +39,7 @@ class Ptex:
         args.append(url)
         return subprocess.run(args=args, stdout=stdout, check=True)
 
-    def fetch_json(self, url: str, **headers: str) -> dict[str, Any]:
+    def fetch_json(self, url: str, **headers: str) -> Any:
         return json.loads(self._fetch(url, stdout=subprocess.PIPE, **headers).stdout)
 
     def fetch_text(self, url: str, **headers: str) -> str:

--- a/tools/src/scie_pants/ptex.py
+++ b/tools/src/scie_pants/ptex.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from argparse import ArgumentParser, Namespace
+from dataclasses import dataclass
+from subprocess import CompletedProcess
+from typing import Any, BinaryIO, Callable, cast
+
+
+@dataclass(frozen=True)
+class Ptex:
+    @classmethod
+    def from_exe(cls, exe: str) -> Ptex:
+        return cls(exe)
+
+    @classmethod
+    def add_options(cls, parser: ArgumentParser) -> Callable[[Namespace], Ptex]:
+        parser.add_argument(
+            "--ptex-path",
+            dest="ptex",
+            required=True,
+            type=cls.from_exe,
+            # The path of a ptex binary.
+            help=argparse.SUPPRESS,
+        )
+        return lambda options: cast(Ptex, options.ptex)
+
+    _exe: str
+
+    def _fetch(self, url: str, stdout: int, **headers: str) -> CompletedProcess:
+        args = [self._exe]
+        for header, value in headers.items():
+            args.extend(("-H", f"{header}: {value}"))
+        args.append(url)
+        return subprocess.run(args=args, stdout=stdout, check=True)
+
+    def fetch_json(self, url: str, **headers: str) -> dict[str, Any]:
+        return json.loads(self._fetch(url, stdout=subprocess.PIPE, **headers).stdout)
+
+    def fetch_text(self, url: str, **headers: str) -> str:
+        return self._fetch(url, stdout=subprocess.PIPE, **headers).stdout.decode()
+
+    def fetch_to_fp(self, url: str, fp: BinaryIO, **headers: str) -> None:
+        self._fetch(url, stdout=fp.fileno(), **headers)

--- a/tools/src/scie_pants/record_scie_pants_info.py
+++ b/tools/src/scie_pants/record_scie_pants_info.py
@@ -1,0 +1,51 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import subprocess
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import NoReturn
+
+from scie_pants.log import fatal, init_logging
+
+
+def main() -> NoReturn:
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        required=True,
+        help="The base directory of this scie's bindings",
+    )
+    parser.add_argument(
+        "--scie",
+        required=True,
+        help="The path of the current scie executable.",
+    )
+    options = parser.parse_args()
+
+    # N.B.: This installs an excepthook that gracefully handles uncaught exceptions; so any raises
+    # or uncaught exceptions below here are clean ways to exit non-zero with useful console output.
+    init_logging(base_dir=options.base_dir, log_name="record-scie-pants-info")
+
+    env_file = os.environ.get("SCIE_BINDING_ENV")
+    if not env_file:
+        fatal("Expected SCIE_BINDING_ENV to be set in the environment")
+
+    version = subprocess.run(
+        args=[options.scie],
+        env={"PANTS_BOOTSTRAP_VERSION": "report"},
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    with open(env_file, "a") as fp:
+        print(f"VERSION={version}", file=fp)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/src/scie_pants/update_scie_pants.py
+++ b/tools/src/scie_pants/update_scie_pants.py
@@ -36,8 +36,6 @@ EXE_EXTENSION = sysconfig.get_config_var("EXE") or ""
 GITHUB_API_BASE_URL = "https://api.github.com/repos/pantsbuild/scie-pants"
 BINARY_NAME = "scie-pants"
 
-ReleaseData = Dict[str, Any]
-
 
 @dataclass(frozen=True)
 class Release:
@@ -185,7 +183,7 @@ def verify_release(scie: PurePath) -> str:
     return (
         subprocess.run(
             args=[str(scie)],
-            env={**os.environ, "SCIE_BOOT": "version"},
+            env={**os.environ, "PANTS_BOOTSTRAP_VERSION": "report"},
             stdout=subprocess.PIPE,
             check=True,
         )

--- a/tools/src/scie_pants/update_scie_pants.py
+++ b/tools/src/scie_pants/update_scie_pants.py
@@ -1,0 +1,263 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import hashlib
+import io
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+from argparse import ArgumentParser
+from dataclasses import dataclass
+from pathlib import Path, PurePath
+from subprocess import CalledProcessError
+from typing import Any, Dict, List, NoReturn, cast
+
+from packaging.version import Version
+
+from scie_pants.log import fatal, info, init_logging, warn
+from scie_pants.ptex import Ptex
+
+log = logging.getLogger(__name__)
+
+
+RELEASE_TAG_MATCHER = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+EXE_EXTENSION = sysconfig.get_config_var("EXE") or ""
+
+# This type is not accurate, release data can contain bool values we test, namely "draft" and
+# "prerelease" fields, but here Python truthiness lets things typecheck.
+ReleaseData = Dict[str, Any]
+
+GITHUB_API_BASE_URL = "https://api.github.com/repos/pantsbuild/scie-pants"
+BINARY_NAME = "scie-pants"
+
+
+@dataclass(frozen=True)
+class Release:
+    version: Version
+    file_name: str
+    binary_url: str
+    binary_sha256_url: str
+
+    @classmethod
+    def from_api_response(
+        cls, version: Version, platform: str, release_data: dict[str, Any]
+    ) -> Release | None:
+        binary_name = f"{BINARY_NAME}-{platform}{EXE_EXTENSION}"
+        binary_sha256_name = f"{binary_name}.sha256"
+        binary_url = None
+        binary_sha256_url = None
+        for asset in release_data.get("assets", []):
+            name = asset.get("name")
+            if binary_name == name:
+                binary_url = asset.get("browser_download_url")
+            elif binary_sha256_name == name:
+                binary_sha256_url = asset.get("browser_download_url")
+            if binary_url and binary_sha256_url:
+                return cls(version, binary_name, binary_url, binary_sha256_url)
+        log.debug(
+            f"No release for {BINARY_NAME} {version} compatible with {platform} was found in: "
+            f"{json.dumps(release_data, indent=2)}"
+        )
+        return None
+
+
+class ReleaseNotFoundError(Exception):
+    pass
+
+
+def get_release(ptex: Ptex, platform: str, version: str) -> Release:
+    try:
+        release_data = cast(
+            dict[str, Any], ptex.fetch_json(f"{GITHUB_API_BASE_URL}/releases/tags/v{version}")
+        )
+    except (CalledProcessError, OSError) as e:
+        raise ReleaseNotFoundError(str(e))
+
+    release = Release.from_api_response(Version(version), platform, release_data)
+    if release is None:
+        raise ReleaseNotFoundError(f"There were no compatible artifacts for {platform}.")
+
+    return release
+
+
+def find_latest_production_release(ptex: Ptex, platform: str) -> Release | None:
+    releases = cast(list[dict[str, Any]], ptex.fetch_json(f"{GITHUB_API_BASE_URL}/releases"))
+
+    latest_releases = []
+    for release_data in releases:
+        if release_data.get("draft") or release_data.get("prerelease"):
+            continue
+        tag_name = release_data.get("tag_name")
+        if not tag_name:
+            continue
+        match = RELEASE_TAG_MATCHER.match(tag_name)
+        if not match:
+            log.debug(
+                f"Skipping tag {tag_name} since it does not match {RELEASE_TAG_MATCHER.pattern}"
+            )
+            continue
+        version = Version(match["version"])
+        release = Release.from_api_response(version, platform, release_data)
+        if release:
+            latest_releases.append(release)
+
+    if not latest_releases:
+        log.debug(
+            f"No releases for {BINARY_NAME} compatible with {platform} found in: "
+            f"{json.dumps(releases, indent=2)}"
+        )
+        return None
+
+    # We want the highest version; so this needs to be a reverse sort.
+    latest_releases.sort(reverse=True, key=lambda rel: rel.version)
+    return latest_releases[0]
+
+
+def install_release(ptex: Ptex, release: Release, scie: Path) -> Path:
+    # The `.sha256` checksum file format is a single line with two fields, space separated.
+    # The 1st field is the hexadecimal checksum and the second field the name of the file it applies
+    # to. See: https://man7.org/linux/man-pages/man1/sha256sum.1.html
+    expected_sha256, _ = ptex.fetch_text(release.binary_sha256_url).strip().split(" ", maxsplit=1)
+
+    download_dir = Path(tempfile.mkdtemp())
+    atexit.register(shutil.rmtree, download_dir, ignore_errors=True)
+
+    binary = download_dir / release.file_name
+    with open(binary, "wb") as fp:
+        ptex.fetch_to_fp(release.binary_url, fp)
+
+    # TODO(John Sirois): Ideally this would not be 2-pass and we'd hash the download stream inline.
+    digest = hashlib.sha256()
+    with open(binary, "rb") as fp:
+        for chunk in iter(lambda: fp.read(io.DEFAULT_BUFFER_SIZE), b""):
+            digest.update(chunk)
+    actual_sha256 = digest.hexdigest()
+    if expected_sha256 != actual_sha256:
+        eol = os.linesep
+        raise ValueError(
+            f"The binary downloaded from {release.binary_url} is invalid.{eol}"
+            f"The expected fingerprint from {release.binary_sha256_url} was:{eol}"
+            f"  {expected_sha256}{eol}"
+            f"The actual fingerprint of the downloaded file is:{eol}"
+            f"  {actual_sha256}",
+        )
+
+    # Mark the binary as executable. This is needed on Unix but not on Windows, where its harmless.
+    binary.chmod(0o755)
+
+    # We first move the running scie before replacing it. This satisfies Windows constraints
+    # surrounding manipulation of running binaries.
+    backup = scie.rename(scie.with_suffix(".bak"))
+    try:
+        shutil.move(str(binary), str(scie))
+    except OSError:
+        warn(f"A backup is saved in {backup}")
+        raise
+    return backup
+
+
+def verify_release(scie: PurePath) -> str:
+    return (
+        subprocess.run(
+            args=[str(scie)],
+            env={**os.environ, "SCIE_BOOT": "version"},
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+
+def main() -> NoReturn:
+    parser = ArgumentParser()
+    get_ptex = Ptex.add_options(parser)
+    parser.add_argument(
+        "--platform",
+        required=True,
+        # The current platform tag (<OS>-<ARCH>)
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        required=True,
+        # The base directory of this scie's bindings.
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--scie",
+        type=Path,
+        required=True,
+        # The path of the current scie executable.
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--current-version",
+        type=Version,
+        required=True,
+        # The version of the current scie executable.
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "version",
+        nargs="?",
+        type=str,
+        default=None,
+        help="The version of scie-pants to update to; defaults to the latest stable version",
+    )
+    options = parser.parse_args()
+
+    # N.B.: This installs an excepthook that gracefully handles uncaught exceptions; so any raises
+    # or uncaught exceptions below here are clean ways to exit non-zero with useful console output.
+    init_logging(base_dir=options.base_dir, log_name="update")
+
+    ptex = get_ptex(options)
+    if options.version is not None:
+        try:
+            release = get_release(ptex, version=options.version, platform=options.platform)
+        except ReleaseNotFoundError as e:
+            fatal(f"Failed to find {BINARY_NAME} release for version {options.version}: {e}")
+    else:
+        maybe_release = find_latest_production_release(ptex, platform=options.platform)
+        if not maybe_release or maybe_release.version < options.current_version:
+            info("No new releases of scie-pants were found.")
+            sys.exit(0)
+        release = maybe_release
+
+    scie = options.scie
+    backup = install_release(ptex, release, scie)
+    try:
+        version = verify_release(scie)
+    except (CalledProcessError, OSError):
+        warn(f"Failed to verify scie-pants {release.version} installation at {scie}.")
+        warn(f"A backup is saved in {backup}")
+        raise
+
+    if release.version != Version(version):
+        warn(f"A backup is saved in {backup}")
+        fatal(
+            f"Installed scie-pants {release.version} to {scie} but the installation reports "
+            f"version {version}."
+        )
+
+    info(f"Successfully installed sie=pants {version} to {scie}")
+    try:
+        backup.unlink(missing_ok=True)
+    except OSError as e:
+        warn(f"Failed to remove old version of scie-pants at {backup}: {e}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/src/scie_pants/update_scie_pants.py
+++ b/tools/src/scie_pants/update_scie_pants.py
@@ -33,12 +33,10 @@ log = logging.getLogger(__name__)
 RELEASE_TAG_MATCHER = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
 EXE_EXTENSION = sysconfig.get_config_var("EXE") or ""
 
-# This type is not accurate, release data can contain bool values we test, namely "draft" and
-# "prerelease" fields, but here Python truthiness lets things typecheck.
-ReleaseData = Dict[str, Any]
-
 GITHUB_API_BASE_URL = "https://api.github.com/repos/pantsbuild/scie-pants"
 BINARY_NAME = "scie-pants"
+
+ReleaseData = Dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -231,7 +229,7 @@ def main() -> NoReturn:
     else:
         maybe_release = find_latest_production_release(ptex, platform=options.platform)
         if not maybe_release or maybe_release.version < options.current_version:
-            info("No new releases of scie-pants were found.")
+            info(f"No new releases of {BINARY_NAME} were found.")
             sys.exit(0)
         release = maybe_release
 
@@ -240,22 +238,22 @@ def main() -> NoReturn:
     try:
         version = verify_release(scie)
     except (CalledProcessError, OSError):
-        warn(f"Failed to verify scie-pants {release.version} installation at {scie}.")
+        warn(f"Failed to verify {BINARY_NAME} {release.version} installation at {scie}.")
         warn(f"A backup is saved in {backup}")
         raise
 
     if release.version != Version(version):
         warn(f"A backup is saved in {backup}")
         fatal(
-            f"Installed scie-pants {release.version} to {scie} but the installation reports "
+            f"Installed {BINARY_NAME} {release.version} to {scie} but the installation reports "
             f"version {version}."
         )
 
-    info(f"Successfully installed sie=pants {version} to {scie}")
+    info(f"Successfully installed {BINARY_NAME} {version} to {scie}")
     try:
         backup.unlink(missing_ok=True)
     except OSError as e:
-        warn(f"Failed to remove old version of scie-pants at {backup}: {e}")
+        warn(f"Failed to remove old version of {BINARY_NAME} at {backup}: {e}")
     sys.exit(0)
 
 


### PR DESCRIPTION
You can now execute `SCIE_BOOT=update scie-pants` to upgrade if possible
or use `SCIE_BOOT=update scie-pants <version>` to switch to the given
scie-pants version if it is available.

Fixes #8