### PR TITLE
Fix up self-update to skip current version.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@
 
 This release fixes a bug using `SCIE_BOOT=update scie-pants` to have
 `scie-pants` update itself to the latest stable release. Previously, it
-would always update to itself if there was no greater version stable
-released. Now, it properly short circuits and informs that there is no
+would always update to itself if there was no greater stable version
+released. Now, it properly short-circuits and informs that there is no
 newer version available.
 
 ## 0.1.8

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.1.9
+
+This release fixes a bug using `SCIE_BOOT=update scie-pants` to have
+`scie-pants` update itself to the latest stable release. Previously, it
+would always update to itself if there was no greater version stable
+released. Now, it properly short circuits and informs that there is no
+newer version available.
+
 ## 0.1.8
 
 The 1st public release of the project.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 name = "scie-pants"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/tools/src/scie_pants/update_scie_pants.py
+++ b/tools/src/scie_pants/update_scie_pants.py
@@ -255,7 +255,7 @@ def main() -> NoReturn:
         maybe_release = find_latest_production_release(
             ptex, platform=options.platform, github_api_bearer_token=options.github_api_bearer_token
         )
-        if not maybe_release or maybe_release.version < options.current_version:
+        if not maybe_release or maybe_release.version <= options.current_version:
             info(f"No new releases of {BINARY_NAME} were found.")
             sys.exit(0)
         release = maybe_release


### PR DESCRIPTION
Previously the scie-pants would update itself to its same version instead of short circuiting.