### PR TITLE
Achieve parity with one_step_setup and then some.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,5 @@ jobs:
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             cargo run -p package -- test \
               --tools-pex dist/tools.pex --scie-pants dist/scie-pants-linux-x86_64 \
+              --tools-pex-mismatch-warn
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, macOS-11-ARM64, windows-2022]
+        os: [ubuntu-22.04, macos-11, macOS-11-ARM64, windows-2022]
     steps:
       - uses: actions/checkout@v3
       - name: Check Formatting
@@ -71,6 +71,9 @@ jobs:
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie --tools-pex dist/tools.pex \
               '
+          echo
+          echo "Running under: $(uname -a)"
+          echo
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             cargo run -p package -- test \
               --tools-pex dist/tools.pex --scie-pants dist/scie-pants-linux-x86_64 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   org-check:
     name: Check GitHub Organization
     if: github.repository_owner == 'pantsbuild'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Noop
         run: "true"
@@ -59,7 +59,7 @@ jobs:
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             cargo run -p package -- test
       - name: Build, Package & Integration Tests
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           mkdir dist
           cargo run -p package -- --dest-dir dist/ tools

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,17 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,12 +368,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "nix"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,16 +379,6 @@ dependencies = [
  "memoffset",
  "pin-utils",
  "static_assertions",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -446,25 +419,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pomsky"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2325e4138bcceff534b0149cb30d08099d2b08f15c65b7bdf7c33b16c5907d4d"
-dependencies = [
- "nom",
- "thiserror",
-]
-
-[[package]]
-name = "pomsky-macro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5997a1ccb23752151a0463191b5b88fa678ce39fa711c64b2a211ede9e1d8166"
-dependencies = [
- "pomsky",
-]
 
 [[package]]
 name = "pretty_env_logger"
@@ -513,20 +467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "pyver"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8437765dce7370ae968d4094568a3ce57a8b74fd51197e9b665560a1ae183d9"
-dependencies = [
- "anyhow",
- "derivative",
- "lazy_static",
- "pomsky-macro",
- "regex",
- "serde",
 ]
 
 [[package]]
@@ -614,10 +554,10 @@ dependencies = [
  "log",
  "logging_timer",
  "nix",
- "pyver",
  "serde",
  "tempfile",
  "toml",
+ "uuid",
 ]
 
 [[package]]
@@ -777,6 +717,15 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ env_logger = { version = "0.10", default-features = false }
 log = { workspace = true }
 logging_timer = "1.1"
 nix = "0.26"
-pyver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tempfile = { workspace = true }
 toml = "0.5"
+uuid = { version = "1.2", features = ["v4"] }

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -91,19 +91,21 @@
             "description": "Runs a hermetic Pants installation.",
             "env": {
               "=PATH": "{scie.env.PATH}:{scie.bindings.install:VIRTUAL_ENV}/bin",
-              "=PANTS_VERSION": "{scie.bindings.install:PANTS_VERSION}"
+              "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
+              "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}"
             },
             "exe": "{scie.bindings.install:VIRTUAL_ENV}/bin/pants",
             "args": [
               "--pants-bin-name={scie.env.PANTS_BIN_NAME}",
-              "{scie.bindings.install:PANTS_SHA_FIND_LINKS}"
+              "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },
           "pants-debug": {
             "description": "Runs a hermetic Pants installation with a debug server for debugging Pants code.",
             "env": {
               "=PATH": "{scie.env.PATH}:{scie.bindings.install:VIRTUAL_ENV}/bin",
-              "=PANTS_VERSION": "{scie.bindings.install:PANTS_VERSION}"
+              "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
+              "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}"
             },
             "exe": "{scie.bindings.install:VIRTUAL_ENV}/bin/python",
             "args": [
@@ -114,7 +116,7 @@
               "--wait-for-client",
               "{scie.bindings.install:VIRTUAL_ENV}/bin/pants",
               "--pants-bin-name={scie.env.PANTS_BIN_NAME}",
-              "{scie.bindings.install:PANTS_SHA_FIND_LINKS}"
+              "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },
           "bootstrap-tools": {
@@ -122,21 +124,22 @@
             "env": {
               "PEX_.*": null,
               "=PEX_ROOT": "{scie.bindings}/pex_root",
-              "=PEX_PYTHON_PATH": "{scie.files.{scie.env.PYTHON}-{scie.platform}}/python/bin/{scie.env.PYTHON}"
+              "=PEX_PYTHON_PATH": "{scie.files.{scie.bindings.configure:PYTHON}-{scie.platform}}/python/bin/{scie.bindings.configure:PYTHON}"
             },
-            "exe": "{scie.files.{scie.env.PYTHON}-{scie.platform}}/python/bin/{scie.env.PYTHON}",
+            "exe": "{scie.files.{scie.bindings.configure:PYTHON}-{scie.platform}}/python/bin/{scie.bindings.configure:PYTHON}",
             "args": [
               "{tools.pex}",
               "bootstrap-tools",
               "--python-distribution-hash",
-              "{scie.files:hash.{scie.env.PYTHON}-{scie.platform}}",
+              "{scie.files:hash.{scie.bindings.configure:PYTHON}-{scie.platform}}",
               "--pants-version",
-              "{scie.env.PANTS_VERSION}"
+              "{scie.bindings.configure:PANTS_VERSION}"
             ]
           },
           "update": {
             "description": "Update scie-pants.",
             "env": {
+              "PEX_.*": null,
               "=PEX_ROOT": "{scie.bindings}/pex_root",
               "=PEX_PYTHON_PATH": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9"
             },
@@ -170,6 +173,7 @@
           "scie-pants-info": {
             "description": "Records information about the current scie-pants binary.",
             "env": {
+              "PEX_.*": null,
               "=PEX_ROOT": "{scie.bindings}/pex_root",
               "=PEX_PYTHON_PATH": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9"
             },
@@ -183,27 +187,46 @@
               "{scie}"
             ]
           },
+          "configure": {
+            "description": "Prompts the user for missing Pants configuration if needed.",
+            "env": {
+              "PEX_.*": null,
+              "=PEX_ROOT": "{scie.bindings}/pex_root",
+              "=PEX_PYTHON_PATH": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9",
+              "PANTS_VERSION_PROMPT_SALT": "{scie.env.PANTS_VERSION_PROMPT_SALT}"
+            },
+            "exe": "{scie.files.python3.9-{scie.platform}}/python/bin/python3.9",
+            "args": [
+              "{tools.pex}",
+              "configure-pants",
+              "--ptex-path",
+              "{ptex}",
+              "--pants-version",
+              "{scie.env.PANTS_VERSION}",
+              "--pants-sha",
+              "{scie.env.PANTS_SHA}",
+              "--pants-config",
+              "{scie.env.PANTS_TOML}",
+              "--github-api-bearer-token",
+              "{scie.env.PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN}",
+              "{scie.bindings}"
+            ]
+          },
           "install": {
             "description": "Installs a hermetic Pants environment from PyPI or binaries.pantsbuild.org with optional debug support.",
             "env": {
               "PEX_.*": null,
               "=PEX_ROOT": "{scie.bindings}/pex_root",
-              "=PEX_PYTHON_PATH": "{scie.files.{scie.env.PYTHON}-{scie.platform}}/python/bin/{scie.env.PYTHON}"
+              "=PEX_PYTHON_PATH": "{scie.files.{scie.bindings.configure:PYTHON}-{scie.platform}}/python/bin/{scie.bindings.configure:PYTHON}"
             },
-            "exe": "{scie.files.{scie.env.PYTHON}-{scie.platform}}/python/bin/{scie.env.PYTHON}",
+            "exe": "{scie.files.{scie.bindings.configure:PYTHON}-{scie.platform}}/python/bin/{scie.bindings.configure:PYTHON}",
             "args": [
               "{tools.pex}",
               "install-pants",
-              "--ptex-path",
-              "{ptex}",
-              "--pants-config",
-              "{scie.env.PANTS_BUILDROOT_OVERRIDE}/pants.toml",
               "--pants-version",
-              "{scie.env.PANTS_VERSION}",
-              "--pants-sha",
-              "{scie.env.PANTS_SHA}",
-              "--github-api-bearer-token",
-              "{scie.env.PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN}",
+              "{scie.bindings.configure:PANTS_VERSION}",
+              "--find-links",
+              "{scie.bindings.configure:FIND_LINKS}",
               "--debug",
               "{scie.env.PANTS_DEBUG}",
               "--debugpy-requirement",

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -735,7 +735,7 @@ fn test(
         integration_test!("Verifying PANTS_SHA is respected");
         execute(
             Command::new(scie_pants_scie)
-                .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
+                .env("PANTS_SHA", "8719cfe3ee6d1a31158a3719fc200517ce7752a2")
                 .args(["--no-verify-config", "-V"]),
         )?;
 

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -744,7 +744,7 @@ fn test(
         integration_test!("Verifying PANTS_SHA is respected");
         execute(
             Command::new(scie_pants_scie)
-                .env("PANTS_SHA", "8719cfe3ee6d1a31158a3719fc200517ce7752a2")
+                .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
                 .args(["--no-verify-config", "-V"]),
         )?;
 

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -730,6 +730,14 @@ fn test(
                 .args(["bootstrap-cache-key"]),
         )?;
 
+        // PANTS_SHA handling.
+        integration_test!("Verifying PANTS_SHA is respected");
+        execute(
+            Command::new(scie_pants_scie)
+                .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
+                .args(["--no-verify-config", "-V"]),
+        )?;
+
         integration_test!(
             "Verifying --python-repos-repos is used prior to Pants 2.13 (no warnings should be \
             issued by Pants)"
@@ -737,14 +745,6 @@ fn test(
         execute(
             Command::new(scie_pants_scie)
                 .env("PANTS_VERSION", "2.12.1")
-                .args(["--no-verify-config", "-V"]),
-        )?;
-
-        // PANTS_SHA handling.
-        integration_test!("Verifying PANTS_SHA is respected");
-        execute(
-            Command::new(scie_pants_scie)
-                .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
                 .args(["--no-verify-config", "-V"]),
         )?;
 

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -730,7 +730,6 @@ fn test(
                 .args(["bootstrap-cache-key"]),
         )?;
 
-        integration_test!("Verifying PANTS_SHA is respected");
         // TODO(John Sirois): The --no-pantsd here works around a fairly prevalent Pants crash on
         // Linux x86_64 along the lines of the following, but sometimes varying:
         // >> Verifying PANTS_SHA is respected
@@ -746,10 +745,16 @@ fn test(
         // Thread 0x00007efe30b75540 (most recent call first):
         // <no Python frame>
         // Error: Command "/home/runner/work/scie-pants/scie-pants/dist/scie-pants-linux-x86_64" "--no-verify-config" "-V" failed with exit code: None
+        if matches!(*CURRENT_PLATFORM, Platform::LinuxX86_64) {
+            log!(Color::Yellow, "Turning off pantsd for remaining tests.");
+            env::set_var("PANTS_PANTSD", "False");
+        }
+
+        integration_test!("Verifying PANTS_SHA is respected");
         execute(
             Command::new(scie_pants_scie)
                 .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
-                .args(["--no-pantsd", "--no-verify-config", "-V"]),
+                .args(["--no-verify-config", "-V"]),
         )?;
 
         integration_test!(

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -730,12 +730,26 @@ fn test(
                 .args(["bootstrap-cache-key"]),
         )?;
 
-        // PANTS_SHA handling.
         integration_test!("Verifying PANTS_SHA is respected");
+        // TODO(John Sirois): The --no-pantsd here works around a fairly prevalent Pants crash on
+        // Linux x86_64 along the lines of the following, but sometimes varying:
+        // >> Verifying PANTS_SHA is respected
+        // Bootstrapping Pants 2.14.0a0+git8e381dbf using cpython 3.9.15
+        // Installing pantsbuild.pants==2.14.0a0+git8e381dbf into a virtual environment at /home/runner/.cache/nce/67f27582b3729c677922eb30c5c6e210aa54badc854450e735ef41cf25ac747f/bindings/venvs/2.14.0a0+git8e381dbf
+        // New virtual environment successfully created at /home/runner/.cache/nce/67f27582b3729c677922eb30c5c6e210aa54badc854450e735ef41cf25ac747f/bindings/venvs/2.14.0a0+git8e381dbf.
+        // 18:11:53.75 [INFO] Initializing scheduler...
+        // 18:11:53.97 [INFO] Scheduler initialized.
+        // 2.14.0a0+git8e381dbf
+        // Fatal Python error: PyGILState_Release: thread state 0x7efe18001140 must be current when releasing
+        // Python runtime state: finalizing (tstate=0x1f4b810)
+        //
+        // Thread 0x00007efe30b75540 (most recent call first):
+        // <no Python frame>
+        // Error: Command "/home/runner/work/scie-pants/scie-pants/dist/scie-pants-linux-x86_64" "--no-verify-config" "-V" failed with exit code: None
         execute(
             Command::new(scie_pants_scie)
                 .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
-                .args(["--no-verify-config", "-V"]),
+                .args(["--no-pantsd", "--no-verify-config", "-V"]),
         )?;
 
         integration_test!(

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -296,6 +296,15 @@ fn touch(path: &Path) -> ExitResult {
     })
 }
 
+fn canonicalize(path: &Path) -> Result<PathBuf, Exit> {
+    path.canonicalize().map_err(|e| {
+        Code::FAILURE.with_message(format!(
+            "Failed to canonicalize {path} to an absolute, resolved path: {e}",
+            path = path.display()
+        ))
+    })
+}
+
 fn binary_full_name(name: &str) -> String {
     format!(
         "{name}-{platform}{exe}",
@@ -918,8 +927,8 @@ fn maybe_build(args: &Args, build_context: &BuildContext) -> Result<Option<PathB
         } => {
             test(
                 &build_context.workspace_root,
-                tools_pex,
-                scie_pants,
+                &canonicalize(tools_pex)?,
+                &canonicalize(scie_pants)?,
                 *tools_pex_mismatch_warn,
             )?;
             Ok(None)
@@ -934,7 +943,7 @@ fn maybe_build(args: &Args, build_context: &BuildContext) -> Result<Option<PathB
             test(
                 &build_context.workspace_root,
                 &tools_pex,
-                scie_pants,
+                &canonicalize(scie_pants)?,
                 *tools_pex_mismatch_warn,
             )?;
             Ok(None)
@@ -948,7 +957,7 @@ fn maybe_build(args: &Args, build_context: &BuildContext) -> Result<Option<PathB
             let scie_pants = build_scie_pants_scie(build_context, &skinny_scie_tools, tools_pex)?;
             test(
                 &build_context.workspace_root,
-                tools_pex,
+                &canonicalize(tools_pex)?,
                 &scie_pants,
                 *tools_pex_mismatch_warn,
             )?;

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -764,11 +764,7 @@ fn test(
 
     integration_test!("Verifying initializing a new Pants project works");
     let new_project_dir = create_tempdir()?;
-    execute(
-        Command::new("git")
-            .arg("init")
-            .arg(new_project_dir.path()),
-    )?;
+    execute(Command::new("git").arg("init").arg(new_project_dir.path()))?;
     let project_subdir = new_project_dir.path().join("subdir").join("sub-subdir");
     ensure_directory(&project_subdir, false)?;
     execute_with_input(

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,38 +1,18 @@
 // Copyright 2022 Pants project contributors.
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::fmt::{Display, Formatter};
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use logging_timer::time;
-use pyver::PackageVersion;
 use serde::Deserialize;
 
 use crate::build_root::BuildRoot;
 
-#[derive(Debug, Deserialize)]
-#[serde(try_from = "String")]
-pub struct Version(PackageVersion);
-
-impl TryFrom<String> for Version {
-    type Error = anyhow::Error;
-
-    fn try_from(value: String) -> std::result::Result<Self, Self::Error> {
-        PackageVersion::new(value.as_str()).map(Self)
-    }
-}
-
-impl Display for Version {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 #[derive(Default, Deserialize)]
 pub(crate) struct Global {
     #[serde(default)]
-    pub(crate) pants_version: Option<Version>,
+    pub(crate) pants_version: Option<String>,
 }
 
 #[derive(Default, Deserialize)]
@@ -54,8 +34,8 @@ pub(crate) struct PantsConfig {
 }
 
 impl PantsConfig {
-    pub(crate) fn package_version(&self) -> Option<&PackageVersion> {
-        self.config.global.pants_version.as_ref().map(|pv| &pv.0)
+    pub(crate) fn package_version(&self) -> Option<String> {
+        self.config.global.pants_version.clone()
     }
 
     pub(crate) fn build_root(&self) -> &Path {

--- a/tools/src/scie_pants.dist-info/entry_points.txt
+++ b/tools/src/scie_pants.dist-info/entry_points.txt
@@ -1,5 +1,6 @@
 [console_scripts]
 bootstrap-tools = scie_pants.bootstrap_tools:main
+configure-pants = scie_pants.configure_pants:main
 install-pants = scie_pants.install_pants:main
 update-scie-pants = scie_pants.update_scie_pants:main
 record-scie-pants-info = scie_pants.record_scie_pants_info:main

--- a/tools/src/scie_pants/configure_pants.py
+++ b/tools/src/scie_pants/configure_pants.py
@@ -1,0 +1,136 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import NoReturn
+
+from packaging.version import Version
+
+from scie_pants.log import fatal, info, init_logging, warn
+from scie_pants.pants_version import (
+    determine_latest_stable_version,
+    determine_sha_version,
+    determine_tag_version,
+)
+from scie_pants.ptex import Ptex
+
+
+def prompt(message: str, default: bool) -> bool:
+    raw_answer = input(f"{message} ({'Y/n' if default else 'N/y'}): ")
+    answer = raw_answer.strip().lower()
+    if not answer:
+        return default
+    return answer in ("y", "yes")
+
+
+def prompt_for_pants_version(pants_config: Path) -> bool:
+    warn(
+        f"The `pants.toml` at {pants_config} has no `pants_version` configured in the `GLOBAL` "
+        f"section."
+    )
+    return prompt(f"Would you like set `pants_version` to the latest stable release?", default=True)
+
+
+def prompt_for_pants_config() -> Path | None:
+    cwd = os.getcwd()
+    buildroot = Path(cwd)
+    if shutil.which("git"):
+        result = subprocess.run(
+            args=["git", "rev-parse", "--show-toplevel"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            buildroot = Path(os.fsdecode(result.stdout.strip()))
+
+    info(f"No Pants configuration was found at or above {cwd}.")
+    if prompt(f"Would you like to configure {buildroot} as a Pants project?", default=True):
+        return buildroot / "pants.toml"
+    return None
+
+
+def main() -> NoReturn:
+    parser = ArgumentParser()
+    get_ptex = Ptex.add_options(parser)
+    parser.add_argument("--pants-sha", help="The Pants sha to install (trumps --version)")
+    parser.add_argument("--pants-version", help="The Pants version to install")
+    parser.add_argument("--pants-config", help="The path of the pants.toml file")
+    parser.add_argument(
+        "--github-api-bearer-token", help="The GITHUB_TOKEN to use if running in CI context."
+    )
+    parser.add_argument("base_dir", nargs=1, help="The base directory to create Pants venvs in.")
+    options = parser.parse_args()
+
+    base_dir = Path(options.base_dir[0])
+    init_logging(base_dir=base_dir, log_name="configure")
+
+    env_file = os.environ.get("SCIE_BINDING_ENV")
+    if not env_file:
+        fatal("Expected SCIE_BINDING_ENV to be set in the environment")
+
+    ptex = get_ptex(options)
+
+    find_links_dir = base_dir / "find_links"
+
+    finalizers = []
+    pants_config = Path(options.pants_config) if options.pants_config else None
+    if options.pants_sha:
+        resolve_info = determine_sha_version(
+            ptex=ptex, sha=options.pants_sha, find_links_dir=find_links_dir
+        )
+        version = resolve_info.sha_version
+    elif options.pants_version:
+        resolve_info = determine_tag_version(
+            ptex=ptex,
+            pants_version=options.pants_version,
+            find_links_dir=find_links_dir,
+            github_api_bearer_token=options.github_api_bearer_token,
+        )
+        version = resolve_info.stable_version
+    else:
+        if pants_config:
+            if not prompt_for_pants_version(options.pants_config):
+                sys.exit(1)
+        else:
+            maybe_pants_config = prompt_for_pants_config()
+            if not maybe_pants_config:
+                sys.exit(1)
+            pants_config = maybe_pants_config
+
+        configure_version, resolve_info = determine_latest_stable_version(
+            ptex=ptex,
+            pants_config=pants_config,
+            find_links_dir=find_links_dir,
+            github_api_bearer_token=options.github_api_bearer_token,
+        )
+        finalizers.append(configure_version)
+        version = resolve_info.stable_version
+
+    if pants_config is None:
+        fatal("Failed to configure a pants.toml")
+
+    build_root = pants_config.parent
+    python = "python3.8" if version < Version("2.5") else "python3.9"
+
+    for finalizer in finalizers:
+        finalizer()
+
+    with open(env_file, "a") as fp:
+        print(f"FIND_LINKS={resolve_info.find_links}", file=fp)
+        print(f"PANTS_BUILDROOT_OVERRIDE={build_root}", file=fp)
+        print(f"PANTS_SHA_FIND_LINKS={resolve_info.pants_find_links_option(version)}", file=fp)
+        print(f"PANTS_VERSION={version}", file=fp)
+        print(f"PYTHON={python}", file=fp)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -3,186 +3,23 @@
 
 from __future__ import annotations
 
-import importlib.resources
-import json
 import logging
 import os
 import subprocess
 import sys
-import urllib.parse
 from argparse import ArgumentParser
-from dataclasses import dataclass
 from pathlib import Path
-from subprocess import CalledProcessError, CompletedProcess
-from typing import Any, BinaryIO, Callable, Iterable, Iterator, NoReturn
-from xml.etree import ElementTree
+from typing import Iterable, NoReturn
 
-import tomlkit
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from scie_pants.log import fatal, info, init_logging, warn
-from scie_pants.ptex import Ptex
+from scie_pants.log import fatal, info, init_logging
 
 log = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class FindLinksRepo:
-    url: str
-
-    def iter_pip_options(self) -> Iterator[str]:
-        yield "--find-links"
-        yield self.url
-
-
-@dataclass(frozen=True)
-class ResolveInfo:
-    stable_version: Version
-    sha_version: Version
-    find_links: FindLinksRepo
-
-    def iter_pip_find_links_options(self) -> Iterator[str]:
-        yield from self.find_links.iter_pip_options()
-
-    def pants_find_links_option(self) -> str:
-        if self.stable_version in SpecifierSet("<2.14.0", prereleases=True):
-            return f"--python-repos-repos={self.find_links.url}"
-        return f"--python-repos-find-links={self.find_links.url}"
-
-
-def determine_find_links(
-    ptex: Ptex,
-    pants_version: str,
-    sha: str,
-    find_links_dir: Path,
-    include_pants_distributions_in_findlinks: bool,
-) -> ResolveInfo:
-    abbreviated_sha = sha[:8]
-    sha_version = Version(f"{pants_version}+git{abbreviated_sha}")
-
-    list_bucket_results = ElementTree.fromstring(
-        ptex.fetch_text(f"https://binaries.pantsbuild.org?prefix=wheels/3rdparty/{sha}")
-    )
-
-    find_links_file = find_links_dir / pants_version / abbreviated_sha / "index.html"
-    find_links_file.parent.mkdir(parents=True, exist_ok=True)
-    find_links_file.unlink(missing_ok=True)
-    with find_links_file.open("wb") as fp:
-        # N.B.: S3 bucket listings use a default namespace. Although the URI is apparently stable,
-        # we decouple from it with the wildcard.
-        for key in list_bucket_results.findall("./{*}Contents/{*}Key"):
-            bucket_path = str(key.text)
-            fp.write(
-                f'<a href="https://binaries.pantsbuild.org/{urllib.parse.quote(bucket_path)}">'
-                f"{os.path.basename(bucket_path)}"
-                f"</a>{os.linesep}".encode()
-            )
-        fp.flush()
-        if include_pants_distributions_in_findlinks:
-            pantsbuild_pants_find_links = (
-                "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/"
-                f"{sha}/{urllib.parse.quote(str(sha_version))}/index.html"
-            )
-            ptex.fetch_to_fp(pantsbuild_pants_find_links, fp)
-
-    return ResolveInfo(
-        stable_version=Version(pants_version),
-        sha_version=sha_version,
-        find_links=FindLinksRepo(f"file://{find_links_file}"),
-    )
-
-
-def determine_tag_version(
-    ptex: Ptex, pants_version: str, find_links_dir: Path, github_api_bearer_token: str | None = None
-) -> ResolveInfo:
-    tag = f"release_{pants_version}"
-
-    # N.B.: The tag database was created with the following in a Pants clone:
-    # git tag --list release_* | \
-    #   xargs -I@ bash -c 'jq --arg T @ --arg C $(git rev-parse @^{commit}) -n "{(\$T): \$C}"' | \
-    #   jq -s 'add' > pants_release_tags.json
-    tags = json.loads(importlib.resources.read_text("scie_pants", "pants_release_tags.json"))
-    commit_sha = tags.get(tag, "")
-
-    if not commit_sha:
-        mapping_file_url = f"https://binaries.pantsbuild.org/tags/pantsbuild.pants/{tag}"
-        log.debug(
-            f"Failed to look up the commit for Pants {tag} in the local database, trying a lookup "
-            f"at {mapping_file_url} next."
-        )
-        try:
-            commit_sha = ptex.fetch_text(mapping_file_url).strip()
-        except CalledProcessError as e:
-            log.debug(
-                f"Failed to look up the commit for Pants {tag} at binaries.pantsbuild.org, trying "
-                f"GitHub API requests next: {e}"
-            )
-
-    # The GitHub API requests are rate limited to 60 per hour un-authenticated; so we guard
-    # these with the database of old releases and then the binaries.pantsbuild.org lookups above.
-    if not commit_sha:
-        github_api_url = (
-            f"https://api.github.com/repos/pantsbuild/pants/git/refs/tags/{urllib.parse.quote(tag)}"
-        )
-        headers = (
-            {"Authorization": f"Bearer {github_api_bearer_token}"}
-            if github_api_bearer_token
-            else {}
-        )
-        github_api_tag_url = ptex.fetch_json(github_api_url, **headers)["object"]["url"]
-        commit_sha = ptex.fetch_json(github_api_tag_url, **headers)["object"]["sha"]
-
-    return determine_find_links(
-        ptex,
-        pants_version,
-        commit_sha,
-        find_links_dir,
-        include_pants_distributions_in_findlinks=False,
-    )
-
-
-def determine_sha_version(ptex: Ptex, sha: str, find_links_dir: Path) -> ResolveInfo:
-    version_file_url = (
-        f"https://raw.githubusercontent.com/pantsbuild/pants/{sha}/src/python/pants/VERSION"
-    )
-    pants_version = ptex.fetch_text(version_file_url).strip()
-    return determine_find_links(
-        ptex, pants_version, sha, find_links_dir, include_pants_distributions_in_findlinks=True
-    )
-
-
-def determine_latest_stable_version(
-    ptex: Ptex, pants_config: Path, find_links_dir: Path, github_api_bearer_token: str | None = None
-) -> tuple[Callable[[], None], ResolveInfo]:
-    info(f"Fetching latest stable Pants version since none is configured")
-    pants_version = ptex.fetch_json("https://pypi.org/pypi/pantsbuild.pants/json")["info"][
-        "version"
-    ]
-
-    def configure_version():
-        backup = None
-        if pants_config.exists():
-            info(f'Setting [GLOBAL] pants_version = "{pants_version}" in {pants_config}')
-            config = tomlkit.loads(pants_config.read_text())
-            backup = f"{pants_config}.bak"
-        else:
-            info(f"Creating {pants_config} and configuring it to use Pants {pants_version}")
-            config = tomlkit.document()
-        global_section = config.setdefault("GLOBAL", {})
-        global_section["pants_version"] = pants_version
-        if backup:
-            warn(f"Backing up {pants_config} to {backup}")
-            pants_config.replace(backup)
-        pants_config.write_text(tomlkit.dumps(config))
-
-    return configure_version, determine_tag_version(
-        ptex, pants_version, find_links_dir, github_api_bearer_token
-    )
-
-
 def install_pants(
-    resolve_info: ResolveInfo, venv_dir: Path, prompt: str, pants_requirements: Iterable[str]
+    venv_dir: Path, prompt: str, pants_requirements: Iterable[str], find_links: str | None
 ) -> None:
     subprocess.run(
         args=[
@@ -198,6 +35,8 @@ def install_pants(
     )
     python = venv_dir / "bin" / "python"
 
+    find_links_options = ("--find-links", find_links) if find_links else ()
+
     def pip_install(*args: str) -> None:
         subprocess.run(
             args=[
@@ -207,7 +46,7 @@ def install_pants(
                 "pip",
                 "install",
                 "--quiet",
-                *resolve_info.iter_pip_find_links_options(),
+                *find_links_options,
                 *args,
             ],
             check=True,
@@ -221,12 +60,13 @@ def install_pants(
 
 def main() -> NoReturn:
     parser = ArgumentParser()
-    parser.add_argument("--pants-sha", help="The Pants sha to install (trumps --version)")
-    parser.add_argument("--pants-version", type=str, help="The Pants version to install")
-    get_ptex = Ptex.add_options(parser)
-    parser.add_argument("--pants-config", help="The path of the pants.toml file")
     parser.add_argument(
-        "--github-api-bearer-token", help="The GITHUB_TOKEN to use if running in CI context."
+        "--pants-version", type=Version, required=True, help="The Pants version to install"
+    )
+    parser.add_argument(
+        "--find-links",
+        type=str,
+        help="The find links repo pointing to Pants pre-built wheels for the given Pants version",
     )
     parser.add_argument("--debug", type=bool, help="Install with debug capabilities.")
     parser.add_argument("--debugpy-requirement", help="The debugpy requirement to install")
@@ -240,47 +80,16 @@ def main() -> NoReturn:
     if not env_file:
         fatal("Expected SCIE_BINDING_ENV to be set in the environment")
 
-    ptex = get_ptex(options)
-
     venvs_dir = base_dir / "venvs"
-    find_links_dir = base_dir / "find_links"
 
-    finalizers = []
-    if options.pants_sha:
-        resolve_info = determine_sha_version(
-            ptex=ptex, sha=options.pants_sha, find_links_dir=find_links_dir
-        )
-        version = resolve_info.sha_version
-    elif options.pants_version:
-        resolve_info = determine_tag_version(
-            ptex=ptex,
-            pants_version=options.pants_version,
-            find_links_dir=find_links_dir,
-            github_api_bearer_token=options.github_api_bearer_token,
-        )
-        version = resolve_info.stable_version
-    else:
-        if not options.pants_config:
-            fatal(
-                "The --pants-config option must be set when neither --pants-sha nor "
-                "--pants-version is set."
-            )
-        configure_version, resolve_info = determine_latest_stable_version(
-            ptex=ptex,
-            pants_config=Path(options.pants_config),
-            find_links_dir=find_links_dir,
-            github_api_bearer_token=options.github_api_bearer_token,
-        )
-        finalizers.append(configure_version)
-        version = resolve_info.stable_version
-
+    version = options.pants_version
     python_version = ".".join(map(str, sys.version_info[:3]))
     info(f"Bootstrapping Pants {version} using {sys.implementation.name} {python_version}")
 
     pants_requirements = [f"pantsbuild.pants=={version}"]
     if options.debug:
         debugpy_requirement = options.debugpy_requirement or "debugpy==1.6.0"
-        pants_requirements.append("debugpy==1.6.0")
+        pants_requirements.append(debugpy_requirement)
         venv_dir = venvs_dir / f"{version}-{debugpy_requirement}"
         prompt = f"Pants {version} [{debugpy_requirement}]"
     else:
@@ -289,19 +98,14 @@ def main() -> NoReturn:
 
     info(f"Installing {' '.join(pants_requirements)} into a virtual environment at {venv_dir}")
     install_pants(
-        resolve_info=resolve_info,
         venv_dir=venv_dir,
         prompt=prompt,
         pants_requirements=pants_requirements,
+        find_links=options.find_links,
     )
-    for finalizer in finalizers:
-        finalizer()
-
     info(f"New virtual environment successfully created at {venv_dir}.")
 
     with open(env_file, "a") as fp:
-        print(f"PANTS_VERSION={version}", file=fp)
-        print(f"PANTS_SHA_FIND_LINKS={resolve_info.pants_find_links_option()}", file=fp)
         print(f"VIRTUAL_ENV={venv_dir}", file=fp)
 
     sys.exit(0)

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -1,0 +1,173 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import importlib.resources
+import json
+import logging
+import os
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import Callable, Iterator
+from xml.etree import ElementTree
+
+import tomlkit
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+from scie_pants.log import info, warn
+from scie_pants.ptex import Ptex
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolveInfo:
+    stable_version: Version
+    sha_version: Version
+    find_links: str
+
+    def pants_find_links_option(self, pants_version_selected: Version) -> str:
+        # We only want to add the find-links repo for PANTS_SHA invocations so that plugins can
+        # resolve Pants the only place it can be found in that case - our ~private
+        # binaries.pantsbuild.org S3 find-links bucket.
+        operator = "-" if pants_version_selected == self.stable_version else "+"
+        option_name = (
+            "repos"
+            if self.stable_version in SpecifierSet("<2.14.0", prereleases=True)
+            else "find-links"
+        )
+        return f"--python-repos-{option_name}={operator}['{self.find_links}']"
+
+
+def determine_find_links(
+    ptex: Ptex,
+    pants_version: str,
+    sha: str,
+    find_links_dir: Path,
+    include_pants_distributions_in_findlinks: bool,
+) -> ResolveInfo:
+    abbreviated_sha = sha[:8]
+    sha_version = Version(f"{pants_version}+git{abbreviated_sha}")
+
+    list_bucket_results = ElementTree.fromstring(
+        ptex.fetch_text(f"https://binaries.pantsbuild.org?prefix=wheels/3rdparty/{sha}")
+    )
+
+    find_links_file = find_links_dir / pants_version / abbreviated_sha / "index.html"
+    find_links_file.parent.mkdir(parents=True, exist_ok=True)
+    find_links_file.unlink(missing_ok=True)
+    with find_links_file.open("wb") as fp:
+        # N.B.: S3 bucket listings use a default namespace. Although the URI is apparently stable,
+        # we decouple from it with the wildcard.
+        for key in list_bucket_results.findall("./{*}Contents/{*}Key"):
+            bucket_path = str(key.text)
+            fp.write(
+                f'<a href="https://binaries.pantsbuild.org/{urllib.parse.quote(bucket_path)}">'
+                f"{os.path.basename(bucket_path)}"
+                f"</a>{os.linesep}".encode()
+            )
+        fp.flush()
+        if include_pants_distributions_in_findlinks:
+            pantsbuild_pants_find_links = (
+                "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/"
+                f"{sha}/{urllib.parse.quote(str(sha_version))}/index.html"
+            )
+            ptex.fetch_to_fp(pantsbuild_pants_find_links, fp)
+
+    return ResolveInfo(
+        stable_version=Version(pants_version),
+        sha_version=sha_version,
+        find_links=f"file://{find_links_file}",
+    )
+
+
+def determine_tag_version(
+    ptex: Ptex, pants_version: str, find_links_dir: Path, github_api_bearer_token: str | None = None
+) -> ResolveInfo:
+    tag = f"release_{pants_version}"
+
+    # N.B.: The tag database was created with the following in a Pants clone:
+    # git tag --list release_* | \
+    #   xargs -I@ bash -c 'jq --arg T @ --arg C $(git rev-parse @^{commit}) -n "{(\$T): \$C}"' | \
+    #   jq -s 'add' > pants_release_tags.json
+    tags = json.loads(importlib.resources.read_text("scie_pants", "pants_release_tags.json"))
+    commit_sha = tags.get(tag, "")
+
+    if not commit_sha:
+        mapping_file_url = f"https://binaries.pantsbuild.org/tags/pantsbuild.pants/{tag}"
+        log.debug(
+            f"Failed to look up the commit for Pants {tag} in the local database, trying a lookup "
+            f"at {mapping_file_url} next."
+        )
+        try:
+            commit_sha = ptex.fetch_text(mapping_file_url).strip()
+        except CalledProcessError as e:
+            log.debug(
+                f"Failed to look up the commit for Pants {tag} at binaries.pantsbuild.org, trying "
+                f"GitHub API requests next: {e}"
+            )
+
+    # The GitHub API requests are rate limited to 60 per hour un-authenticated; so we guard
+    # these with the database of old releases and then the binaries.pantsbuild.org lookups above.
+    if not commit_sha:
+        github_api_url = (
+            f"https://api.github.com/repos/pantsbuild/pants/git/refs/tags/{urllib.parse.quote(tag)}"
+        )
+        headers = (
+            {"Authorization": f"Bearer {github_api_bearer_token}"}
+            if github_api_bearer_token
+            else {}
+        )
+        github_api_tag_url = ptex.fetch_json(github_api_url, **headers)["object"]["url"]
+        commit_sha = ptex.fetch_json(github_api_tag_url, **headers)["object"]["sha"]
+
+    return determine_find_links(
+        ptex,
+        pants_version,
+        commit_sha,
+        find_links_dir,
+        include_pants_distributions_in_findlinks=False,
+    )
+
+
+def determine_sha_version(ptex: Ptex, sha: str, find_links_dir: Path) -> ResolveInfo:
+    version_file_url = (
+        f"https://raw.githubusercontent.com/pantsbuild/pants/{sha}/src/python/pants/VERSION"
+    )
+    pants_version = ptex.fetch_text(version_file_url).strip()
+    return determine_find_links(
+        ptex, pants_version, sha, find_links_dir, include_pants_distributions_in_findlinks=True
+    )
+
+
+def determine_latest_stable_version(
+    ptex: Ptex, pants_config: Path, find_links_dir: Path, github_api_bearer_token: str | None = None
+) -> tuple[Callable[[], None], ResolveInfo]:
+    info(f"Fetching latest stable Pants version since none is configured")
+    pants_version = ptex.fetch_json("https://pypi.org/pypi/pantsbuild.pants/json")["info"][
+        "version"
+    ]
+
+    def configure_version():
+        backup = None
+        if pants_config.exists():
+            info(f'Setting [GLOBAL] pants_version = "{pants_version}" in {pants_config}')
+            config = tomlkit.loads(pants_config.read_text())
+            backup = f"{pants_config}.bak"
+        else:
+            info(f"Creating {pants_config} and configuring it to use Pants {pants_version}")
+            config = tomlkit.document()
+        global_section = config.setdefault("GLOBAL", {})
+        global_section["pants_version"] = pants_version
+        if backup:
+            warn(f"Backing up {pants_config} to {backup}")
+            pants_config.replace(backup)
+        pants_config.write_text(tomlkit.dumps(config))
+
+    return configure_version, determine_tag_version(
+        ptex, pants_version, find_links_dir, github_api_bearer_token
+    )


### PR DESCRIPTION
Pants will now configure `pants_version` to be latest stable if
`pants.toml` is present but `pants_version` is not. Further, it will
establish a `pants.toml` if none is present. If the CWD is nested in
a `.git` dir, the `pants.toml` is created there instead.

To support configuration in these cases, break out a `configure`
binding to handle prompting and version selection separate from the
`install` binding.