### PR TITLE
Upgrade to scie-jump 0.7.2 to fix several bugs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.1.11
+
+This release fixes `SCIE_BOOT=update ./scie-pants`; i.e.: updating `scie-pants` when invoking
+`scie-pants` vis a relative path. It also fixes `scie-pants` to work when on the `PATH` as `pants`
+in any repo that already contains the `./pants` bash script.
+
 ## 0.1.10
 
 This release folds [one step setup](

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ The `scie-pants` binary will re-install versions of Pants you have already insta
 directory that is different from the `~/.cache/pants/setup` directory used by the `./pants` script.
 This is a one-time event per Pants version.
 
-Naming the `scie-pants` binary `pants` will lead to an obscure error currently in a repo with an
-existing `./pants`. That is tracked [here](https://github.com/pantsbuild/scie-pants/issues/28).
-
 The `scie-pants` does not work in the Pants repo itself. That repo has a special `./pants` script
 and declares no `pants_version`. As such, if you run `scie-pants` in the Pants repo, you'll be
 prompted to set up the latest stable version of Pants. You can just answer no and remember not to

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -802,7 +802,7 @@ fn test(
         )?;
         let bin_dir = clone_root.path().join("bin");
         ensure_directory(&bin_dir, false)?;
-        hardlink(scie_pants_scie, bin_dir.join("pants").as_path())?;
+        copy(scie_pants_scie, bin_dir.join("pants").as_path())?;
         let new_path = if let Ok(existing_path) = env::var("PATH") {
             format!(
                 "{bin_dir}{path_sep}{existing_path}",

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -22,7 +22,7 @@ use url::Url;
 const BINARY: &str = "scie-pants";
 
 const PTEX_TAG: &str = "v0.6.0";
-const SCIE_JUMP_TAG: &str = "v0.7.1";
+const SCIE_JUMP_TAG: &str = "v0.7.2";
 
 const CARGO: &str = env!("CARGO");
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
@@ -789,6 +789,35 @@ fn test(
                 .current_dir(existing_project_dir.path()),
             "Y".as_bytes(),
         )?;
+
+        integration_test!(
+            "Verify scie-pants can be used as `pants` in a repo with the `pants` script"
+        );
+        // This verifies a fix for https://github.com/pantsbuild/scie-pants/issues/28.
+        let clone_root = create_tempdir()?;
+        execute(
+            Command::new("git")
+                .args(["clone", "https://github.com/pantsbuild/example-django"])
+                .current_dir(clone_root.path()),
+        )?;
+        let bin_dir = clone_root.path().join("bin");
+        ensure_directory(&bin_dir, false)?;
+        hardlink(scie_pants_scie, bin_dir.join("pants").as_path())?;
+        let new_path = if let Ok(existing_path) = env::var("PATH") {
+            format!(
+                "{bin_dir}{path_sep}{existing_path}",
+                bin_dir = bin_dir.display(),
+                path_sep = PATHSEP
+            )
+        } else {
+            format!("{bin_dir}", bin_dir = bin_dir.display())
+        };
+        execute(
+            Command::new("pants")
+                .arg("-V")
+                .env("PATH", new_path)
+                .current_dir(clone_root.path().join("example-django")),
+        )?;
     }
 
     // Max Python supported is 3.8 and only Linux and macOS x86_64 wheels were released.
@@ -819,10 +848,13 @@ fn test(
     execute(Command::new(scie_pants_scie).env("SCIE_BOOT", "update"))?;
 
     integration_test!("Verifying downgrade works");
+    // Additionally, we exercise using a relative path to the scie-jump binary which triggered
+    // https://github.com/pantsbuild/scie-pants/issues/38 in the past.
     execute(
-        Command::new(scie_pants_scie)
+        Command::new(PathBuf::from(".").join(scie_pants_scie.file_name().unwrap()))
             .env("SCIE_BOOT", "update")
-            .arg("0.1.8"),
+            .arg("0.1.8")
+            .current_dir(scie_pants_scie.parent().unwrap()),
     )?;
 
     Ok(())


### PR DESCRIPTION
This fixes argv0 handling such that relative paths do not confuse
`scie-pants` leading to errors during self update or when running
`scie-pants` as `pants` from the PATH in a repo with a `./pants` script.

Fixes #28
Fixes #38