### PR TITLE
Upgrade to Rust 1.66.1.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.66.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
This avoids a potential CVE:
  https://blog.rust-lang.org/2023/01/10/cve-2022-46176.html