### PR TITLE
Fix `.pants.bootstrap` handling to only gather vars.

### DIFF
--- a/.pants.bootstrap
+++ b/.pants.bootstrap
@@ -1,3 +1,10 @@
+function should_be_ignored() {
+  # Normally `set` would print information about functions as well as variables; causing scie-pants
+  # to emit warnings about skipping un-parseable env vars. This function stresses that corner in
+  # integration tests.
+  return
+}
+
 # Ensure GIT_COMMIT is set
 : ${GIT_COMMIT:=$(git rev-parse HEAD)}
 

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -741,10 +741,21 @@ fn test(
         *CURRENT_PLATFORM,
         Platform::LinuxX86_64 | Platform::MacOSAarch64 | Platform::MacOSX86_64
     ) {
+        integration_test!("Linting, testing and packaging the tools codebase");
+        execute(
+            Command::new(scie_pants_scie)
+                .args(["fmt", "lint", "check", "test", "package", "::"])
+                .env("PEX_SCRIPT", "Does not exist!"),
+        )?;
+
         integration_test!("Checking .pants.bootstrap handling ignores bash functions");
+        // N.B.: We run this test after 1st having run the test above to ensure pants is already
+        // bootstrapped so that we don't get stderr output from that process. We also use
+        // `--no-pantsd` to avoid spurious pantsd startup stderr log lines just in case pantsd found
+        // a need to restart.
         let output = execute(
             Command::new(scie_pants_scie)
-                .args(["-V"])
+                .args(["--no-pantsd", "-V"])
                 .stderr(Stdio::piped()),
         )?;
         assert!(
@@ -752,13 +763,6 @@ fn test(
             "Expected no warnings to be printed when handling .pants.bootstrap, found:\n{warnings}",
             warnings = String::from_utf8_lossy(&output.stderr)
         );
-
-        integration_test!("Linting, testing and packaging the tools codebase");
-        execute(
-            Command::new(scie_pants_scie)
-                .args(["fmt", "lint", "check", "test", "package", "::"])
-                .env("PEX_SCRIPT", "Does not exist!"),
-        )?;
 
         integration_test!(
             "Verifying the tools.pex built by the package crate matches the tools.pex built by \

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -8,7 +8,7 @@ use std::fs::Permissions;
 use std::io::Write;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use clap::{arg, command, Parser, Subcommand};
@@ -741,6 +741,18 @@ fn test(
         *CURRENT_PLATFORM,
         Platform::LinuxX86_64 | Platform::MacOSAarch64 | Platform::MacOSX86_64
     ) {
+        integration_test!("Checking .pants.bootstrap handling ignores bash functions");
+        let output = execute(
+            Command::new(scie_pants_scie)
+                .args(["-V"])
+                .stderr(Stdio::piped()),
+        )?;
+        assert!(
+            output.stderr.is_empty(),
+            "Expected no warnings to be printed when handling .pants.bootstrap, found:\n{warnings}",
+            warnings = String::from_utf8_lossy(&output.stderr)
+        );
+
         integration_test!("Linting, testing and packaging the tools codebase");
         execute(
             Command::new(scie_pants_scie)

--- a/src/pants_bootstrap.rs
+++ b/src/pants_bootstrap.rs
@@ -46,9 +46,12 @@ impl PantsBootstrap {
                         r#"source "{pants_bootstrap}" >"{capture}" 2>&1; "#,
                         pants_bootstrap = pants_bootstrap.display(),
                         capture = capture.path().display(),
-                    ).as_str(),
-                    r#"set -o posix; IFS=$'\0'; set"#
-                ].join("").as_str(),
+                    )
+                    .as_str(),
+                    r#"set -o posix; IFS=$'\0'; set"#,
+                ]
+                .join("")
+                .as_str(),
             ])
             .output()
             .with_context(|| {


### PR DESCRIPTION
Previously everything reported by the `set` builtin was parsed and this
could include functions and other exotica leading to un-needed warnings.

Fixes #63