### PR TITLE
Remove the Pants Python interpreter from PATH.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
         run: |
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             cargo run -p package -- test
+      - name: Setup Python 3.9
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        uses: actions/setup-python@v4
+        with:
+          # N.B.: We need Python 3.9 for running Pants goals against our tools.pex Python tools
+          # codebase.
+          python-version: "3.9"
       - name: Build, Package & Integration Tests
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -91,7 +91,6 @@
           "pants": {
             "description": "Runs a hermetic Pants installation.",
             "env": {
-              "=PATH": "{scie.env.PATH}:{scie.bindings.install:VIRTUAL_ENV}/bin",
               "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
               "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}"
             },
@@ -104,7 +103,6 @@
           "pants-debug": {
             "description": "Runs a hermetic Pants installation with a debug server for debugging Pants code.",
             "env": {
-              "=PATH": "{scie.env.PATH}:{scie.bindings.install:VIRTUAL_ENV}/bin",
               "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
               "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}"
             },


### PR DESCRIPTION
Since this interpreter is hobbled - it cannot build C extensions - it is
dangerous to have it discoverable on the PATH. Anyone needing to build C
extensions needs to supply their own local Python interpreter.

Fixes #69