### PR TITLE
Delegate to `./pants` when `[DEFAULT] delegate_bootstrap=true`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.SCIE_PANTS_DEV_CACHE }}
-          key: ${{ runner.os }}-${{ runner.arch }}-scie-pants-v1
+          key: ${{ runner.os }}-${{ runner.arch }}-scie-pants-v2
       - name: Build, Package & Integration Tests
         if: ${{ matrix.os == 'macOS-11-ARM64' }}
         run: |

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -118,6 +118,10 @@
               "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },
+          "pants-dev": {
+            "description": "Runs Pants from a local source checkout of the pantsbuild/pants repository, for development.",
+            "exe": "{scie.env.PANTS_BUILDROOT_OVERRIDE}/pants"
+          },
           "bootstrap-tools": {
             "description": "Introspection tools for the Pants bootstrap process.",
             "env": {

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -118,10 +118,6 @@
               "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },
-          "pants-dev": {
-            "description": "Runs Pants from a local source checkout of the pantsbuild/pants repository, for development.",
-            "exe": "{scie.env.PANTS_BUILDROOT_OVERRIDE}/pants"
-          },
           "bootstrap-tools": {
             "description": "Introspection tools for the Pants bootstrap process.",
             "env": {

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -1113,6 +1113,22 @@ index b70ae75..271706a 100644
                 .current_dir(user_repo_dir),
             "The pants_from_sources mode is working.",
         )?;
+
+        integration_test!("Verify delegating to `./pants`.");
+        let result = execute(
+            Command::new(scie_pants_scie)
+                .arg("-V")
+                .current_dir(pants_2_14_1_clone_dir),
+        )?;
+        let stderr = String::from_utf8(result.stderr).map_err(|e| {
+            Code::FAILURE.with_message(format!("Failed to decode Pants stderr: {e}"))
+        })?;
+        let expected_message = "foo bar";
+        assert!(
+          stderr.contains(expected_message),
+          "STDERR did not contain '{expected_message}':\n{stderr}"
+        );
+
     }
 
     // Max Python supported is 3.8 and only Linux and macOS x86_64 wheels were released.

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,12 +20,19 @@ pub(crate) struct DebugPy {
     pub(crate) version: Option<String>,
 }
 
+#[derive(Default, Deserialize)]
+pub(crate) struct Default {
+    pub(crate) delegate_bootstrap: Option<bool>,
+}
+
 #[derive(Deserialize)]
 pub(crate) struct Config {
     #[serde(default, rename = "GLOBAL")]
     pub(crate) global: Global,
     #[serde(default)]
     pub(crate) debugpy: DebugPy,
+    #[serde(default, rename = "DEFAULT")]
+    pub(crate) default: Default,
 }
 
 pub(crate) struct PantsConfig {
@@ -44,6 +51,10 @@ impl PantsConfig {
 
     pub(crate) fn debugpy_version(&self) -> Option<String> {
         self.config.debugpy.version.clone()
+    }
+
+    pub(crate) fn delegate_bootstrap(&self) -> bool {
+        self.config.default.delegate_bootstrap.unwrap_or_default()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,17 @@ fn get_pants_process() -> Result<Process> {
             (None, None, None, false)
         };
 
+    if delegate_bootstrap {
+        let exe = build_root
+            .expect("Failed to locate build root")
+            .join("pants")
+            .into_os_string();
+        return Ok(Process {
+            exe,
+            ..Default::default()
+        });
+    }
+
     let env_pants_sha = env_version("PANTS_SHA")?;
     let env_pants_version = env_version("PANTS_VERSION")?;
     if let (Some(pants_sha), Some(pants_version)) = (&env_pants_sha, &env_pants_version) {
@@ -137,9 +148,7 @@ fn get_pants_process() -> Result<Process> {
     let scie_boot = match env::var_os("PANTS_BOOTSTRAP_TOOLS") {
         Some(_) => "bootstrap-tools",
         None => {
-            if delegate_bootstrap {
-                "pants-dev"
-            } else if pants_debug {
+            if pants_debug {
                 "pants-debug"
             } else {
                 "pants"

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,17 +110,6 @@ fn get_pants_process() -> Result<Process> {
             (None, None, None, false)
         };
 
-    if delegate_bootstrap {
-        let exe = build_root
-            .expect("Failed to locate build root")
-            .join("pants")
-            .into_os_string();
-        return Ok(Process {
-            exe,
-            ..Default::default()
-        });
-    }
-
     let env_pants_sha = env_version("PANTS_SHA")?;
     let env_pants_version = env_version("PANTS_VERSION")?;
     if let (Some(pants_sha), Some(pants_version)) = (&env_pants_sha, &env_pants_version) {
@@ -137,6 +126,17 @@ fn get_pants_process() -> Result<Process> {
     } else {
         None
     };
+
+    if delegate_bootstrap && pants_version == None {
+        let exe = build_root
+            .expect("Failed to locate build root")
+            .join("pants")
+            .into_os_string();
+        return Ok(Process {
+            exe,
+            ..Default::default()
+        });
+    }
 
     info!("Found Pants build root at {build_root:?}");
     info!("The required Pants version is {pants_version:?}");


### PR DESCRIPTION
The choice of config section for the `pants.toml` config file was made to have something that won't choke the regular Pants configuration verification and also not show up in any online help.

Closes #33 
