### PR TITLE
Upgrade Rust to 1.67.0.

### DIFF
--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -1067,9 +1067,7 @@ index 81e3bd7..4236f4b 100755
             })?;
             assert!(
                 stderr.contains(expected_message),
-                "STDERR did not contain {}:\n{}",
-                expected_message,
-                stderr
+                "STDERR did not contain {expected_message}:\n{stderr}"
             );
             Ok(())
         };

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.67.0"
 components = [
   "cargo",
   "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,7 +226,7 @@ impl<T> OrExit<T> for Result<T> {
         match self {
             Ok(item) => item,
             Err(err) => {
-                eprintln!("{:#}", err);
+                eprintln!("{err:#}");
                 std::process::exit(1)
             }
         }


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2023/01/26/Rust-1.67.0.html