### PR TITLE
Prepare the 0.3.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,14 +150,14 @@ jobs:
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.TAP_TOKEN }}
-        # Docs: https://octokit.github.io/rest.js/v19#actions-create-workflow-dispatch
-        script: |
-          await github.rest.actions.createWorkflowDispatch({
-            owner: 'pantsbuild',
-            repo: 'homebrew-tap',
-            workflow_id: 'release.yml',
-            ref: 'main',
-            inputs: {
-              tag: '${{ needs.determine-tag.outputs.release-tag }}'
-            }
-          })
+          # Docs: https://octokit.github.io/rest.js/v19#actions-create-workflow-dispatch
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'pantsbuild',
+              repo: 'homebrew-tap',
+              workflow_id: 'release.yml',
+              ref: 'main',
+              inputs: {
+                tag: '${{ needs.determine-tag.outputs.release-tag }}'
+              }
+            })

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 0.3.1
+## 0.3.2
 
 This release fixes the Pants from sources feature added in 0.3.0 to forward command line arguments
 to the Pants run from sources correctly. Previously the argument list passed was doubled.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,7 +560,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",


### PR DESCRIPTION
The 0.3.1 release did not go out, the issue in the release process is fixed here.