### PR TITLE
Fix github-token value typo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Bump `scie-pants` version in Casks/pants.rb to ${{ needs.determine-tag.outputs.release-tag }}
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.TAP_TOKEN }}
+          github-token: ${{ secrets.PAT_TOKEN }}
           # Docs: https://octokit.github.io/rest.js/v19#actions-create-workflow-dispatch
           script: |
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
The terminology is PAT (Personal Access Token) and the secret is configured as such.