### PR TITLE
Update docker image used in CI to match rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.66.0-alpine3.17 \
+            rust:1.67.0-alpine3.17 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie --tools-pex dist/tools.pex \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.66.0-alpine3.17 \
+            rust:1.67.0-alpine3.17 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie --tools-pex dist/tools.pex \

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,5 @@
 [toolchain]
+# NB: Update the Docker image used by CI when changing this value.
 channel = "1.67.0"
 components = [
   "cargo",


### PR DESCRIPTION
#80 upgraded rust, but did not change the docker images used in CI. Not sure how to automate this without TOML parsing.