### PR TITLE
Set `_PANTS_OVERRIDE_VERSION` when delegate_bootstrap has been overridden.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn get_pants_process() -> Result<Process> {
         None
     };
 
-    if delegate_bootstrap && pants_version == None {
+    if delegate_bootstrap && pants_version.is_none() {
         let exe = build_root
             .expect("Failed to locate build root")
             .join("pants")
@@ -179,6 +179,9 @@ fn get_pants_process() -> Result<Process> {
         ));
     }
     if let Some(version) = pants_version {
+        if delegate_bootstrap {
+            env.push(("_PANTS_OVERRIDE_VERSION".into(), version.clone().into()));
+        }
         env.push(("PANTS_VERSION".into(), version.into()));
     } else {
         // Ensure the install binding always re-runs when no Pants version is found so that the


### PR DESCRIPTION
Special case when running in the Pants source repo and `delegate_bootstrap` is enabled--when a specific version of Pants is requested (either via `pants_version` in the `pants.toml` file or using env vars `PANTS_VERSION` or `PANTS_SHA`) bootstrap using that version of Pants rather than delegating to `./pants`.

Closes #98 