### PR TITLE
Improve Pants help output / CLI fidelity.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.5.0
+
+This release improves `scie-pants` operation with Pants help by ensuring the command line you used
+to invoke Pants is accurately reflected in the help information Pants presents back to you.
+
 ## 0.4.2
 
 This release fixes `.pants.bootstrap` handling to robustly mimic handling by the `./pants` script.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -96,7 +96,6 @@
             },
             "exe": "{scie.bindings.install:VIRTUAL_ENV}/bin/pants",
             "args": [
-              "--pants-bin-name={scie.env.PANTS_BIN_NAME}",
               "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },
@@ -114,7 +113,6 @@
               "127.0.0.1:5678",
               "--wait-for-client",
               "{scie.bindings.install:VIRTUAL_ENV}/bin/pants",
-              "--pants-bin-name={scie.env.PANTS_BIN_NAME}",
               "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -849,7 +849,10 @@ fn test(
                 false,
                 r#"
                 [GLOBAL]
-                pants_version = "2.15.0rc4"
+                pants_version = "2.14.1"
+                # TODO(John Sirois): This works around ongoing issues with pantsd termination
+                # variously crashing or hanging depending on Pants version.
+                pantsd = false
                 [anonymous-telemetry]
                 enabled = false
                 "#,

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -849,7 +849,7 @@ fn test(
                 false,
                 r#"
                 [GLOBAL]
-                pants_version = "2.14.1"
+                pants_version = "2.15.0rc4"
                 [anonymous-telemetry]
                 enabled = false
                 "#,

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -827,6 +827,71 @@ fn test(
                 .env("EXPECTED_LINES", tput_output("lines")?.trim()),
         )?;
 
+        integration_test!("Checking PANTS_BIN_NAME handling");
+        {
+            let check_pants_bin_name_chroot = create_tempdir()?;
+
+            let bin_dir = check_pants_bin_name_chroot.path().join("bin");
+            let project_dir = check_pants_bin_name_chroot.path().join("project");
+            let existing_path =
+                env::split_paths(&env::var_os("PATH").unwrap_or("".into())).collect::<Vec<_>>();
+            let path = env::join_paths(
+                [bin_dir.as_os_str()]
+                    .into_iter()
+                    .chain(existing_path.iter().map(|p| p.as_os_str())),
+            )
+            .unwrap();
+            ensure_directory(&bin_dir, true)?;
+
+            ensure_directory(&project_dir, true)?;
+            write_file(
+                &project_dir.join("pants.toml"),
+                false,
+                r#"
+                [GLOBAL]
+                pants_version = "2.14.1"
+                [anonymous-telemetry]
+                enabled = false
+                "#,
+            )?;
+
+            softlink(scie_pants_scie, &bin_dir.join("foo"))?;
+            softlink(scie_pants_scie, &project_dir.join("bar"))?;
+            let absolute_argv0_path = check_pants_bin_name_chroot.path().join("baz");
+            softlink(scie_pants_scie, &absolute_argv0_path)?;
+
+            let assert_pants_bin_name =
+                |argv0: &str, expected_bin_name: &str, extra_envs: Vec<(_, _)>| -> ExitResult {
+                    let output = String::from_utf8(
+                        execute(
+                            Command::new(argv0)
+                                .arg("help-advanced")
+                                .arg("global")
+                                .env("PATH", &path)
+                                .envs(extra_envs)
+                                .current_dir(&project_dir)
+                                .stdout(Stdio::piped()),
+                        )?
+                        .stdout,
+                    )
+                    .unwrap();
+                    let expected_output =
+                        format!("current value: {expected_bin_name} (from env var PANTS_BIN_NAME)");
+                    assert!(
+                        output.contains(&expected_output),
+                        "Expected:{EOL}{expected_output}{EOL}STDOUT was:{EOL}{output}"
+                    );
+                    Ok(())
+                };
+
+            assert_pants_bin_name("foo", "foo", vec![])?;
+            assert_pants_bin_name("./bar", "./bar", vec![])?;
+
+            let absolute_argv0 = absolute_argv0_path.to_str().unwrap();
+            assert_pants_bin_name(absolute_argv0, absolute_argv0, vec![])?;
+            assert_pants_bin_name(absolute_argv0, "spam", vec![("PANTS_BIN_NAME", "spam")])?;
+        }
+
         integration_test!("Checking .pants.bootstrap handling ignores bash functions");
         // N.B.: We run this test after 1st having run the test above to ensure pants is already
         // bootstrapped so that we don't get stderr output from that process. We also use

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.15.0rc3"
+pants_version = "2.15.0rc4"
 
 backend_packages = [
     "pants.backend.python",

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.15.0rc4"
+pants_version = "2.15.0rc3"
 
 backend_packages = [
     "pants.backend.python",

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,9 +213,13 @@ fn get_pants_process() -> Result<Process> {
         }
     };
 
+    let pants_bin_name = env::var_os("PANTS_BIN_NAME")
+        .or_else(|| env::var_os("SCIE_ARGV0"))
+        .unwrap_or_else(|| scie.clone().into());
+
     let mut env = vec![
         ("SCIE_BOOT".into(), scie_boot.env_value()),
-        ("PANTS_BIN_NAME".into(), scie.clone().into()),
+        ("PANTS_BIN_NAME".into(), pants_bin_name),
         (
             "PANTS_DEBUG".into(),
             if pants_debug { "1" } else { "" }.into(),


### PR DESCRIPTION
Previously scie-pants over-rode Pants help defaulting to `./pants`
in help text by passing `--pants-bin-name` as the absolute path of
scie-pants. Now scie-pants passes the exact argv0 string it was
invoked with and it does so using the `PANTS_BIN_NAME` env var instead
of `--pants-bin-name` to support users over-riding this.

Closes #111