### PR TITLE
Fix `pants run --debug-adapter`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.5.2
+
+This release fixes `scie-pants` to interoperate with `pants run --debug-adapter`. Previously, if
+there was no custom `[debugpy] version` configured, `scie-pants` would cause Pants to error by
+passing the empty string as the `debugpy` `version` requirement string via `PANTS_DEBUGPY_VERSION=`.
+
 ## 0.5.1
 
 This release silences Pip notifications about new Pip versions being available. The Pip used by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,11 +224,10 @@ fn get_pants_process() -> Result<Process> {
             "PANTS_DEBUG".into(),
             if pants_debug { "1" } else { "" }.into(),
         ),
-        (
-            "PANTS_DEBUGPY_VERSION".into(),
-            debugpy_version.unwrap_or_default().into(),
-        ),
     ];
+    if let Some(debugpy_version) = debugpy_version {
+        env.push(("PANTS_DEBUGPY_VERSION".into(), debugpy_version.into()));
+    }
     if let Some(ref build_root) = build_root {
         env.push((
             "PANTS_BUILDROOT_OVERRIDE".into(),


### PR DESCRIPTION
This fixes `scie-pants` to work with `pants run --debug-adapter` by not
setting an empty `PANTS_DEBUGPY_VERSION` env var.