### PR TITLE
Fix Pants installation caching to be per-user.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 0.5.3
+
+This release fixes `scie-pants` caching of Pants installs. Previously a given version of Pants was
+not fully cached and `scie-pants` would do un-necessary network requests when re-using the already
+installed Pants version from a project directory different from the initial installation project
+directory. Now a given version of Pants is fully cached per-user (really per `SCIE_BASE`, which
+defaults to a cache directory under the user's `HOME` dir).
+
 ## 0.5.2
 
 This release fixes `scie-pants` to interoperate with `pants run --debug-adapter`. Previously, if

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -569,8 +570,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scie-pants"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -797,6 +807,17 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -21,3 +21,4 @@ sha2 = "0.10"
 tempfile = { workspace = true }
 termcolor = "1.2"
 url = "2.3"
+walkdir = "2.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ fn get_pants_process() -> Result<Process> {
     let pants_version = if let Some(env_version) = env_pants_version {
         Some(env_version)
     } else if env_pants_sha.is_none() {
-        configured_pants_version
+        configured_pants_version.clone()
     } else {
         None
     };
@@ -233,10 +233,15 @@ fn get_pants_process() -> Result<Process> {
             "PANTS_BUILDROOT_OVERRIDE".into(),
             build_root.as_os_str().to_os_string(),
         ));
-        env.push((
-            "PANTS_TOML".into(),
-            build_root.join("pants.toml").into_os_string(),
-        ));
+        // This should not be conditional. Ideally we'd always set this env var, which is used
+        // by the configure binding, and scie-jump would be smart enough to skip the configure
+        // binding when the install binding is a cache hit.
+        if configured_pants_version.is_none() {
+            env.push((
+                "PANTS_TOML".into(),
+                build_root.join("pants.toml").into_os_string(),
+            ));
+        }
     }
     if let Some(version) = pants_version {
         if delegate_bootstrap {


### PR DESCRIPTION
Previously the configure binding was cached per build root which led to
unwanted configure binding cache-misses when using an already installed
Pants version from a new project directory.

Fixes #129