### PR TITLE
Upgrade to Rust 1.69.0.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.68.2-alpine3.17 \
+              rust:1.69.0-alpine3.17 \
                 sh -c '
                   apk add cmake make musl-dev perl && \
                   cargo run -p package -- --dest-dir dist/ scie --tools-pex dist/tools.pex \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.68.2-alpine3.17 \
+            rust:1.69.0-alpine3.17 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie --tools-pex dist/tools.pex \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.68.2-alpine3.17 \
+            rust:1.69.0-alpine3.17 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie --tools-pex dist/tools.pex \

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,6 @@
 [toolchain]
 # N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.68.2"
+channel = "1.69.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html