### PR TITLE
Support the `PANTS_TOML` env var.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## 0.6.0
+
+Support the `PANTS_TOML` environment variable for specifying a location other than the project's
+build root for Pants configuration file. This was a missed port from the `./pants` script and
+behaves the same: setting the `PANTS_TOML` tells `scie-pants` where to find the config file, but you
+must also tell Pants by using `PANTS_CONFIG_FILES` as well. With these two environment variables set
+and the project's build root demarcated by either a `BUILD_ROOT` or `BUILDROOT` marker file, Pants
+project layouts supported  by `./pants` should now be fully supported by `scie-pants`. Since
+`scie-pants` supports `.env` files you can also populate both env vars there as now to streamline
+the setup.
+
 ## 0.5.4
 
 Support using pants from sources also from a projects subtree not only the project root.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/src/build_root.rs
+++ b/src/build_root.rs
@@ -20,13 +20,14 @@ impl BuildRoot {
 
         let mut cwd = start_search.as_path();
         loop {
-            let config_path = cwd.join("pants.toml");
-            if config_path.is_file() {
-                return Ok(BuildRoot(cwd.to_path_buf()));
+            for marker_file_name in ["pants.toml", "BUILDROOT", "BUILD_ROOT"] {
+                if cwd.join(marker_file_name).is_file() {
+                    return Ok(BuildRoot(cwd.to_path_buf()));
+                }
             }
             cwd = cwd.parent().with_context(|| {
                 format!(
-                    "Failed to find pants.toml starting at {start_search}",
+                    "Failed to find pants.toml, BUILDROOT or BUILD_ROOT starting at {start_search}",
                     start_search = start_search.display()
                 )
             })?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,16 +61,20 @@ impl PantsConfig {
 impl PantsConfig {
     #[time("debug", "PantsConfig::{}")]
     pub(crate) fn parse(build_root: BuildRoot) -> Result<PantsConfig> {
-        let pants_config = build_root.join("pants.toml");
+        let (pants_config, provenance) = if let Some(path) = std::env::var_os("PANTS_TOML") {
+            (path.into(), " (via PANTS_TOML env var)")
+        } else {
+            (build_root.join("pants.toml"), "")
+        };
         let contents = std::fs::read_to_string(&pants_config).with_context(|| {
             format!(
-                "Failed to read Pants config from {path}",
+                "Failed to read Pants config from {path}{provenance}",
                 path = pants_config.display()
             )
         })?;
         let config: Config = toml::from_str(&contents).with_context(|| {
             format!(
-                "Failed to parse Pants config from {path}",
+                "Failed to parse Pants config from {path}{provenance}",
                 path = pants_config.display()
             )
         })?;


### PR DESCRIPTION
This was a missed item from the `./pants` port. Also adds support for
`BUILD_ROOT` & `BUILDROOT` build root marker files which are needed to
support alternate `pants.toml` locations.

Fixes #153