### PR TITLE
Use the pants native-client if it is present in the distribution.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.7.1
+
+Adds support for using the [Pants native client](https://github.com/pantsbuild/pants/pull/11922),
+if it has been included in the Pants distribution. Pants releases starting with `2.17.0a0` are
+expected to include the native client.
+
 ## 0.7.0
 
 This release updates `scie-jump` to 0.11.0 and `ptex` to 0.7.0. The `scie-jump` upgrade brings in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -92,21 +92,10 @@
             "description": "Runs a hermetic Pants installation.",
             "env": {
               "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
-              "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}"
-            },
-            "exe": "{scie.bindings.install:VIRTUAL_ENV}/bin/pants",
-            "args": [
-              "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
-            ]
-          },
-          "pants-maybe-native-client": {
-            "description": "Runs a hermetic Pants installation via the native client (falling back to the legacy client if the native client is not available).",
-            "env": {
-              "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
               "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}",
-              "=_PANTS_SERVER_EXE": "{scie.bindings.install:VIRTUAL_ENV}/bin/pants"
+              "=_PANTS_SERVER_EXE": "{scie.bindings.install:PANTS_SERVER_EXE}"
             },
-            "exe": "{scie.bindings.install:MAYBE_NATIVE_CLIENT_BINARY}",
+            "exe": "{scie.bindings.install:PANTS_CLIENT_EXE}",
             "args": [
               "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]

--- a/package/scie-pants.lift.json
+++ b/package/scie-pants.lift.json
@@ -99,6 +99,18 @@
               "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
             ]
           },
+          "pants-maybe-native-client": {
+            "description": "Runs a hermetic Pants installation via the native client (falling back to the legacy client if the native client is not available).",
+            "env": {
+              "=PANTS_VERSION": "{scie.bindings.configure:PANTS_VERSION}",
+              "PANTS_BUILDROOT_OVERRIDE": "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}",
+              "=_PANTS_SERVER_EXE": "{scie.bindings.install:VIRTUAL_ENV}/bin/pants"
+            },
+            "exe": "{scie.bindings.install:MAYBE_NATIVE_CLIENT_BINARY}",
+            "args": [
+              "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}"
+            ]
+          },
           "pants-debug": {
             "description": "Runs a hermetic Pants installation with a debug server for debugging Pants code.",
             "env": {

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -96,7 +96,7 @@ pub(crate) fn run_integration_tests(
             env::set_var("PANTS_PANTSD", "False");
         }
 
-        test_pants_sha(scie_pants_scie);
+        test_pants_shas(scie_pants_scie);
         test_python_repos_repos(scie_pants_scie);
         test_initialize_new_pants_project(scie_pants_scie);
         test_set_pants_version(scie_pants_scie);
@@ -294,14 +294,21 @@ fn test_pants_bootstrap_tools(scie_pants_scie: &Path) {
     .unwrap();
 }
 
-fn test_pants_sha(scie_pants_scie: &Path) {
-    integration_test!("Verifying PANTS_SHA is respected");
-    execute(
-        Command::new(scie_pants_scie)
-            .env("PANTS_SHA", "8e381dbf90cae57c5da2b223c577b36ca86cace9")
-            .args(["--no-verify-config", "-V"]),
-    )
-    .unwrap();
+fn test_pants_shas(scie_pants_scie: &Path) {
+    for sha in [
+        // initial
+        "8e381dbf90cae57c5da2b223c577b36ca86cace9",
+        // native-client added to wheel
+        "558d843549204bbe49c351d00cdf23402da262c1",
+    ] {
+        integration_test!("Verifying significant PANTS_SHA: {sha}");
+        execute(
+            Command::new(scie_pants_scie)
+                .env("PANTS_SHA", sha)
+                .args(["--no-verify-config", "-V"]),
+        )
+        .unwrap();
+    }
 }
 
 fn test_python_repos_repos(scie_pants_scie: &Path) {

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -302,8 +302,11 @@ fn test_pants_shas(scie_pants_scie: &Path) {
         "558d843549204bbe49c351d00cdf23402da262c1",
     ] {
         integration_test!("Verifying significant PANTS_SHA: {sha}");
+        let existing_project_dir = create_tempdir().unwrap();
+        touch(&existing_project_dir.path().join("pants.toml")).unwrap();
         execute(
             Command::new(scie_pants_scie)
+                .current_dir(existing_project_dir.path())
                 .env("PANTS_SHA", sha)
                 .args(["--no-verify-config", "-V"]),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,6 @@ fn find_pants_installation() -> Result<Option<PantsConfig>> {
 enum ScieBoot {
     BootstrapTools,
     Pants,
-    PantsMaybeNativeClient,
     PantsDebug,
 }
 
@@ -104,7 +103,6 @@ impl ScieBoot {
         match self {
             ScieBoot::BootstrapTools => "bootstrap-tools",
             ScieBoot::Pants => "pants",
-            ScieBoot::PantsMaybeNativeClient => "pants-maybe-native-client",
             ScieBoot::PantsDebug => "pants-debug",
         }
         .into()
@@ -204,13 +202,10 @@ fn get_pants_process() -> Result<Process> {
         env::var("SCIE").context("Failed to retrieve SCIE location from the environment.")?;
 
     let pants_debug = matches!(env::var_os("PANTS_DEBUG"), Some(value) if !value.is_empty());
-    let pants_no_native_client =
-        matches!(env::var_os("PANTS_NO_NATIVE_CLIENT"), Some(value) if !value.is_empty());
     let scie_boot = match env::var_os("PANTS_BOOTSTRAP_TOOLS") {
         Some(_) => ScieBoot::BootstrapTools,
         None if pants_debug => ScieBoot::PantsDebug,
-        None if pants_no_native_client => ScieBoot::Pants,
-        None => ScieBoot::PantsMaybeNativeClient,
+        None => ScieBoot::Pants,
     };
 
     let pants_bin_name = env::var_os("PANTS_BIN_NAME")

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ fn find_pants_installation() -> Result<Option<PantsConfig>> {
 enum ScieBoot {
     BootstrapTools,
     Pants,
+    PantsMaybeNativeClient,
     PantsDebug,
 }
 
@@ -103,6 +104,7 @@ impl ScieBoot {
         match self {
             ScieBoot::BootstrapTools => "bootstrap-tools",
             ScieBoot::Pants => "pants",
+            ScieBoot::PantsMaybeNativeClient => "pants-maybe-native-client",
             ScieBoot::PantsDebug => "pants-debug",
         }
         .into()
@@ -202,15 +204,13 @@ fn get_pants_process() -> Result<Process> {
         env::var("SCIE").context("Failed to retrieve SCIE location from the environment.")?;
 
     let pants_debug = matches!(env::var_os("PANTS_DEBUG"), Some(value) if !value.is_empty());
+    let pants_no_native_client =
+        matches!(env::var_os("PANTS_NO_NATIVE_CLIENT"), Some(value) if !value.is_empty());
     let scie_boot = match env::var_os("PANTS_BOOTSTRAP_TOOLS") {
         Some(_) => ScieBoot::BootstrapTools,
-        None => {
-            if pants_debug {
-                ScieBoot::PantsDebug
-            } else {
-                ScieBoot::Pants
-            }
-        }
+        None if pants_debug => ScieBoot::PantsDebug,
+        None if pants_no_native_client => ScieBoot::Pants,
+        None => ScieBoot::PantsMaybeNativeClient,
     };
 
     let pants_bin_name = env::var_os("PANTS_BIN_NAME")

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -10,6 +10,7 @@ import sys
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Iterable, NoReturn
+from glob import glob
 
 from packaging.version import Version
 
@@ -116,8 +117,13 @@ def main() -> NoReturn:
     )
     info(f"New virtual environment successfully created at {venv_dir}.")
 
+    # TODO: Reference the version after which we can assume existence of this file.
+    native_client_binaries = glob(str(venv_dir / "lib/python*/site-packages/pants/bin/native_client"))
+    maybe_native_client_binary = native_client_binaries[0] if len(native_client_binaries) == 1 else venv_dir / "bin" / "pants"
+
     with open(env_file, "a") as fp:
         print(f"VIRTUAL_ENV={venv_dir}", file=fp)
+        print(f"MAYBE_NATIVE_CLIENT_BINARY={maybe_native_client_binary}", file=fp)
 
     sys.exit(0)
 

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -117,13 +117,15 @@ def main() -> NoReturn:
     )
     info(f"New virtual environment successfully created at {venv_dir}.")
 
+    pants_server_exe = str(venv_dir / "bin" / "pants")
     # Added in https://github.com/pantsbuild/pants/commit/558d843549204bbe49c351d00cdf23402da262c1
     native_client_binaries = glob(str(venv_dir / "lib/python*/site-packages/pants/bin/native_client"))
-    maybe_native_client_binary = native_client_binaries[0] if len(native_client_binaries) == 1 else venv_dir / "bin" / "pants"
+    pants_client_exe = native_client_binaries[0] if len(native_client_binaries) == 1 else pants_server_exe
 
     with open(env_file, "a") as fp:
         print(f"VIRTUAL_ENV={venv_dir}", file=fp)
-        print(f"MAYBE_NATIVE_CLIENT_BINARY={maybe_native_client_binary}", file=fp)
+        print(f"PANTS_SERVER_EXE={pants_server_exe}", file=fp)
+        print(f"PANTS_CLIENT_EXE={pants_client_exe}", file=fp)
 
     sys.exit(0)
 

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -117,7 +117,7 @@ def main() -> NoReturn:
     )
     info(f"New virtual environment successfully created at {venv_dir}.")
 
-    # TODO: Reference the version after which we can assume existence of this file.
+    # Added in https://github.com/pantsbuild/pants/commit/558d843549204bbe49c351d00cdf23402da262c1
     native_client_binaries = glob(str(venv_dir / "lib/python*/site-packages/pants/bin/native_client"))
     maybe_native_client_binary = native_client_binaries[0] if len(native_client_binaries) == 1 else venv_dir / "bin" / "pants"
 

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -8,9 +8,9 @@ import os
 import subprocess
 import sys
 from argparse import ArgumentParser
+from glob import glob
 from pathlib import Path
 from typing import Iterable, NoReturn
-from glob import glob
 
 from packaging.version import Version
 
@@ -119,8 +119,12 @@ def main() -> NoReturn:
 
     pants_server_exe = str(venv_dir / "bin" / "pants")
     # Added in https://github.com/pantsbuild/pants/commit/558d843549204bbe49c351d00cdf23402da262c1
-    native_client_binaries = glob(str(venv_dir / "lib/python*/site-packages/pants/bin/native_client"))
-    pants_client_exe = native_client_binaries[0] if len(native_client_binaries) == 1 else pants_server_exe
+    native_client_binaries = glob(
+        str(venv_dir / "lib/python*/site-packages/pants/bin/native_client")
+    )
+    pants_client_exe = (
+        native_client_binaries[0] if len(native_client_binaries) == 1 else pants_server_exe
+    )
 
     with open(env_file, "a") as fp:
         print(f"VIRTUAL_ENV={venv_dir}", file=fp)


### PR DESCRIPTION
This change uses the `native-client` binary included in `pantsbuild/pants` wheels by https://github.com/pantsbuild/pants/pull/18957 (and further adjusted in https://github.com/pantsbuild/pants/pull/19010) to launch `pants`. See that change for the performance impact.