### PR TITLE
Prepare the 0.7.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 0.7.0
+
+This release updates `scie-jump` to 0.11.0 and `ptex` to 0.7.0. The `scie-jump` upgrade brings in
+a feature not yet used by `scie-pants`, but that will be used when it transitions from `scie-jump`
+to [`science`](https://github.com/a-scie/lift) for its scie building tool in an upcoming release.
+The `ptex` upgrade brings in many fixes in the underlying `curl` code.
+
+The `scie-jump` release notes are here: https://github.com/a-scie/jump/releases/tag/v0.11.0
+The `ptex` release notes are here: https://github.com/a-scie/ptex/releases/tag/v0.7.0
+
 ## 0.6.1
 
 This release fixes `PANTS_SHA` support to properly cache the resulting Pants install.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -28,8 +28,8 @@ use crate::utils::fs::{canonicalize, copy, ensure_directory};
 
 const BINARY: &str = "scie-pants";
 
-const PTEX_TAG: &str = "v0.6.0";
-const SCIE_JUMP_TAG: &str = "v0.10.0";
+const PTEX_TAG: &str = "v0.7.0";
+const SCIE_JUMP_TAG: &str = "v0.11.0";
 
 #[derive(Clone)]
 struct SpecifiedPath(PathBuf);


### PR DESCRIPTION
This updates us to the latest `scie-jump` and `ptex`.