### PR TITLE
Fix Pants native client handling.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.7.2
+
+This release fixes handling of the Pants native client by ensuring it is executable before trying
+to run it.
+
 ## 0.7.1
 
 Adds support for using the [Pants native client](https://github.com/pantsbuild/pants/pull/11922),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -831,11 +831,22 @@ fn test_pants_native_client_perms_issue_182(scie_pants_scie: &Path) {
         issue = issue_link(182)
     );
 
+    let tmpdir = create_tempdir().unwrap();
+
     let pants_release = "2.17.0a1";
+    let pants_toml_content = format!(
+        r#"
+        [GLOBAL]
+        pants_version = "{pants_release}"
+        "#
+    );
+    let pants_toml = tmpdir.path().join("pants.toml");
+    write_file(&pants_toml, false, pants_toml_content).unwrap();
+
     let output = execute(
         Command::new(scie_pants_scie)
-            .env("PANTS_VERSION", pants_release)
-            .args(["--no-verify-config", "-V"])
+            .arg("-V")
+            .current_dir(&tmpdir)
             .stdout(Stdio::piped()),
     );
     assert_eq!(

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -834,8 +834,8 @@ fn test_pants_native_client_perms_issue_182(scie_pants_scie: &Path) {
     let pants_release = "2.17.0a1";
     let output = execute(
         Command::new(scie_pants_scie)
-            .arg("-V")
             .env("PANTS_VERSION", pants_release)
+            .args(["--no-verify-config", "-V"])
             .stdout(Stdio::piped()),
     );
     assert_eq!(

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -128,6 +128,7 @@ pub(crate) fn run_integration_tests(
 
         test_caching_issue_129(scie_pants_scie);
         test_custom_pants_toml_issue_153(scie_pants_scie);
+        test_pants_native_client_perms_issue_182(scie_pants_scie);
     }
 
     // Max Python supported is 3.8 and only Linux and macOS x86_64 wheels were released.
@@ -820,5 +821,25 @@ export PANTS_CONFIG_FILES=${{PANTS_TOML}}
     assert_eq!(
         expected_output.trim(),
         String::from_utf8(output.stdout.to_vec()).unwrap().trim()
+    );
+}
+
+fn test_pants_native_client_perms_issue_182(scie_pants_scie: &Path) {
+    integration_test!(
+        "Verifying scie-pants sets executable perms on the Pants native client binary when \
+        present ({issue})",
+        issue = issue_link(182)
+    );
+
+    let pants_release = "2.17.0a1";
+    let output = execute(
+        Command::new(scie_pants_scie)
+            .arg("-V")
+            .env("PANTS_VERSION", pants_release)
+            .stdout(Stdio::piped()),
+    );
+    assert_eq!(
+        pants_release,
+        decode_output(output.unwrap().stdout).unwrap().trim()
     );
 }

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
+import stat
 import subprocess
 import sys
 from argparse import ArgumentParser
@@ -70,6 +71,10 @@ def install_pants(
     pip_install("--progress-bar", "off", *pants_requirements)
 
 
+def chmod_plus_x(path: str) -> None:
+    os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
 def main() -> NoReturn:
     parser = ArgumentParser()
     parser.add_argument(
@@ -125,6 +130,7 @@ def main() -> NoReturn:
     pants_client_exe = (
         native_client_binaries[0] if len(native_client_binaries) == 1 else pants_server_exe
     )
+    chmod_plus_x(pants_client_exe)
 
     with open(env_file, "a") as fp:
         print(f"VIRTUAL_ENV={venv_dir}", file=fp)


### PR DESCRIPTION
Guard against the Pants wheel not containing an executable native
client / Pip not installing the native client with executable
permissions.

Today this guards the former:
```
$ zipinfo ~/Downloads/pantsbuild.pants-2.17.0a1-cp39-cp39-manylinux2014_x86_64.whl | grep native_client
-rw-r--r--  2.0 unx 24584416 b- defN 23-May-19 23:21 pants/bin/native_client
```

Fixes #182