### PR TITLE
Update scie-pants to scie-jump 0.11.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.8.2
+
+This release fixes handling of environment variables when non-utf8 variables are present in the
+ambient environment.
+
 ## 0.8.1
 
 This release adjusts the `PANTS_SHA` and `PANTS_VERSION` environment variables to be ignored, if

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -455,6 +455,7 @@ dependencies = [
  "log",
  "once_cell",
  "pretty_env_logger",
+ "regex",
  "sha2",
  "tempfile",
  "termcolor",
@@ -533,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -544,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustix"
@@ -573,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1.4"
 log = { workspace = true }
 once_cell = "1.17"
 pretty_env_logger = "0.5"
+regex = "1.8"
 sha2 = "0.10"
 tempfile = { workspace = true }
 termcolor = "1.2"

--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -8,7 +8,7 @@ Python Build Tool: A BusyBox that provides `python`, `pip`, `pex`, `pex3` and `p
 version = "0.7.0"
 
 [lift.scie-jump]
-version = "0.11.0"
+version = "0.11.1"
 
 [[lift.interpreters]]
 id = "cpython"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -12,7 +12,7 @@ version = "0.7.0"
 lazy_argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
 
 [lift.scie-jump]
-version = "0.11.0"
+version = "0.11.1"
 
 [[lift.interpreters]]
 id = "cpython38"

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::env;
+use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 use anyhow::{Context, Result};
+use regex::Regex;
 use tempfile::TempDir;
 use termcolor::{Color, WriteColor};
 
@@ -130,6 +132,7 @@ pub(crate) fn run_integration_tests(
         test_caching_issue_129(scie_pants_scie);
         test_custom_pants_toml_issue_153(scie_pants_scie);
         test_pants_native_client_perms_issue_182(scie_pants_scie);
+        test_non_utf8_env_vars_issue_198(scie_pants_scie);
     }
 
     // Max Python supported is 3.8 and only Linux and macOS x86_64 wheels were released.
@@ -887,4 +890,81 @@ fn test_pants_native_client_perms_issue_182(scie_pants_scie: &Path) {
         pants_release,
         decode_output(output.unwrap().stdout).unwrap().trim()
     );
+}
+
+fn test_non_utf8_env_vars_issue_198(scie_pants_scie: &Path) {
+    integration_test!(
+        "Verifying scie-pants is robust to environments with non-utf8 env vars present ({issue})",
+        issue = issue_link(198)
+    );
+
+    let tmpdir = create_tempdir().unwrap();
+
+    let pants_release = "2.17.0a1";
+    let pants_toml_content = format!(
+        r#"
+        [GLOBAL]
+        pants_version = "{pants_release}"
+        "#
+    );
+    let pants_toml = tmpdir.path().join("pants.toml");
+    write_file(&pants_toml, false, pants_toml_content).unwrap();
+
+    use std::os::unix::ffi::OsStringExt;
+    env::set_var("FOO", OsString::from_vec(vec![b'B', 0xa5, b'R']));
+
+    let err = execute(
+        Command::new(scie_pants_scie)
+            .arg("-V")
+            .env("RUST_LOG", "trace")
+            .stderr(Stdio::piped())
+            .current_dir(&tmpdir),
+    )
+    .unwrap_err();
+    let error_text = err.to_string();
+    // N.B.: This is a very hacky way to confirm the `scie-jump` is done processing env vars and has
+    // exec'd the `scie-pants` native client; which then proceeds to choke on env vars in the same
+    // way scie-jump <= 0.11.0 did using `env::vars()`.
+    assert!(Regex::new(concat!(
+        r#"exe: ".*/bindings/venvs/2\.17\.0a1/lib/python3\.9/"#,
+        r#"site-packages/pants/bin/native_client""#
+    ))
+    .unwrap()
+    .find(&error_text)
+    .is_some());
+    assert!(error_text.contains("[DEBUG TimerFinished] jump::prepare_boot(), Elapsed="));
+    assert!(error_text
+        .contains(r#"panicked at 'called `Result::unwrap()` on an `Err` value: "B\xA5R"'"#));
+
+    // The error path we test below requires flowing through the pantsd path via PyNailgunClient.
+    let err = execute(
+        Command::new(scie_pants_scie)
+            .arg("--pantsd")
+            .arg("-V")
+            .env("PANTS_NO_NATIVE_CLIENT", "1")
+            .stderr(Stdio::piped())
+            .current_dir(&tmpdir),
+    )
+    .unwrap_err();
+    // Here we're asking the native client to exit very early before it processed `env::vars()`; so
+    // the execution makes it into Python code that calls
+    // `PyNailgunClient(...).execute(command, args, modified_env)`. That's Rust code implementing a
+    // Python extension object that also wrongly assumes utf8 when converting env vars.
+    assert!(err.to_string().contains(concat!(
+        r#"UnicodeEncodeError: 'utf-8' codec can't encode character '\udca5' in "#,
+        "position 1: surrogates not allowed"
+    )));
+
+    let output = execute(
+        Command::new(scie_pants_scie)
+            .arg("--no-pantsd")
+            .arg("-V")
+            .env("PANTS_NO_NATIVE_CLIENT", "1")
+            .stdout(Stdio::piped())
+            .current_dir(&tmpdir),
+    )
+    .unwrap();
+    assert_eq!(pants_release, decode_output(output.stdout).unwrap().trim());
+
+    env::remove_var("FOO");
 }


### PR DESCRIPTION
This pulls in a fix for handling of regex env var removal when the
ambient env contains non-utf8 entries. Out of the 4 ways Pants can be
run, two are still broken, but these breaks are inside Pants itself.
Both breaks occur when using pantsd. There is one in the native client
and one in the `PyNailgunClient`. For more about those issues, see:
https://github.com/pantsbuild/pants/issues/19199

Fixes #198