### PR TITLE
Upgrade to Rust 1.70.0.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[registries.crates-io]
-protocol = "sparse"
-
 [target.aarch64-pc-windows-msvc]
 rustflags = [
       # For Windows static msvcrt linking with no need for dll re-distribution.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             docker run --rm \
               -v $PWD:/code \
               -w /code \
-              rust:1.69.0-alpine3.17 \
+              rust:1.70.0-alpine3.18 \
                 sh -c '
                   apk add cmake make musl-dev perl && \
                   cargo run -p package -- --dest-dir dist/ scie-pants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.69.0-alpine3.17 \
+            rust:1.70.0-alpine3.18 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie-pants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.69.0-alpine3.17 \
+            rust:1.70.0-alpine3.18 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie-pants

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,6 @@
 [toolchain]
 # N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.69.0"
+channel = "1.70.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The release announcement is here:
  https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html

Since the sparse index protocol is now default, kill the explicit
configuration of that.