### PR TITLE
Grab latest version from GitHub Release tag

### DIFF
--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -149,11 +149,15 @@ def determine_latest_stable_version(
 ) -> tuple[Callable[[], None], ResolveInfo]:
     info(f"Fetching latest stable Pants version since none is configured")
 
-    latest_tag = ptex.fetch_json("https://github.com/pantsbuild/pants/releases/latest", Accept="application/json")["tag_name"]
+    latest_tag = ptex.fetch_json(
+        "https://github.com/pantsbuild/pants/releases/latest", Accept="application/json"
+    )["tag_name"]
     if not latest_tag.startswith("release_"):
-        fatal(f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"')
+        fatal(
+            f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"'
+        )
 
-    pants_version = latest_tag[len("release_"):]
+    pants_version = latest_tag[len("release_") :]
 
     def configure_version():
         backup = None

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -149,12 +149,22 @@ def determine_latest_stable_version(
 ) -> tuple[Callable[[], None], ResolveInfo]:
     info(f"Fetching latest stable Pants version since none is configured")
 
-    latest_tag = ptex.fetch_json(
-        "https://github.com/pantsbuild/pants/releases/latest", Accept="application/json"
-    )["tag_name"]
+    try:
+        latest_tag = ptex.fetch_json(
+            "https://github.com/pantsbuild/pants/releases/latest", Accept="application/json"
+        )["tag_name"]
+    except Exception as e:
+        fatal(
+            "Couldn't get the latest release by fetching https://github.com/pantsbuild/pants/releases/latest.\n\n"
+            + "If this is unexpected (e.g. GitHub isn't down), please reach out on Slack: https://www.pantsbuild.org/docs/getting-help#slack\n\n"
+            + f"Exception:\n\n{e}"
+        )
+
     if not latest_tag.startswith("release_"):
         fatal(
-            f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"'
+            f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"\n\n'
+            + "Please reach out on Slack: https://www.pantsbuild.org/docs/getting-help#slack or file"
+            + " an issue on GitHub: https://github.com/pantsbuild/pants/issues/new/choose."
         )
 
     pants_version = latest_tag[len("release_") :]

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -168,7 +168,6 @@ def determine_latest_stable_version(
             + " an issue on GitHub: https://github.com/pantsbuild/pants/issues/new/choose."
         )
 
-
     def configure_version():
         backup = None
         if pants_config.exists():

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -18,7 +18,7 @@ import tomlkit
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from scie_pants.log import info, warn
+from scie_pants.log import fatal, info, warn
 from scie_pants.ptex import Ptex
 
 log = logging.getLogger(__name__)

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -149,7 +149,7 @@ def determine_latest_stable_version(
 ) -> tuple[Callable[[], None], ResolveInfo]:
     info(f"Fetching latest stable Pants version since none is configured")
 
-    latest_tag = ptex.fetch_text("https://github.com/pantsbuild/pants/releases/latest", Accept="application/json")["tag_name"]
+    latest_tag = ptex.fetch_json("https://github.com/pantsbuild/pants/releases/latest", Accept="application/json")["tag_name"]
     if not latest_tag.startswith("release_"):
         fatal(f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"')
 

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -168,7 +168,6 @@ def determine_latest_stable_version(
             + " an issue on GitHub: https://github.com/pantsbuild/pants/issues/new/choose."
         )
 
-    pants_version = latest_tag[len("release_") :]
 
     def configure_version():
         backup = None

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -160,7 +160,8 @@ def determine_latest_stable_version(
             + f"Exception:\n\n{e}"
         )
 
-    if not latest_tag.startswith("release_"):
+    prefix, _, pants_version = latest_tag.partition("_")
+    if prefix != "release" or not pants_version:
         fatal(
             f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"\n\n'
             + "Please reach out on Slack: https://www.pantsbuild.org/docs/getting-help#slack or file"

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -148,9 +148,12 @@ def determine_latest_stable_version(
     ptex: Ptex, pants_config: Path, find_links_dir: Path, github_api_bearer_token: str | None = None
 ) -> tuple[Callable[[], None], ResolveInfo]:
     info(f"Fetching latest stable Pants version since none is configured")
-    pants_version = ptex.fetch_json("https://pypi.org/pypi/pantsbuild.pants/json")["info"][
-        "version"
-    ]
+
+    latest_tag = ptex.fetch_text("https://github.com/pantsbuild/pants/releases/latest", Accept="application/json")["tag_name"]
+    if not latest_tag.startswith("release_"):
+        fatal(f'Expected the GitHub Release tagged "latest" to have the "release_" prefix. Got "{latest_tag}"')
+
+    pants_version = latest_tag[len("release_"):]
 
     def configure_version():
         backup = None


### PR DESCRIPTION
As discussed in the latest Pants meetup and [this proposal](https://github.com/pantsbuild/pants/discussions/19443), we're going to move off of PyPI for distribution, and instead leverage GitHub Releases.

Some reasons given for this pivot:
- People ought not to `pip install pantsbuild.pants`
- We ought not to continue eating up PyPI space, which we're already hitting the ceiling for
- We plan on having `scie-pants` use a PEX in the future, and PyPI wouldn't support that workflow
- We want to abstract away, as much is reasonable, that Pants is implemented in Python. And treat it like a black box, where possible.

Currently the latest version is expected to be set by hand. Although that's unlikely to be wrong, we're also changing to have the "latest" marker be [automated](https://github.com/pantsbuild/pants/pull/19444). Therefore we should be able to rely on it with confidence.

Tested and both before/after yielded the same string (with the GitHub URL performing slightly faster)