### PR TITLE
Switch scie-pants to use Pants PEX, when supported

### DIFF
--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -203,8 +203,8 @@ PEX_PYTHON_PATH = "#{cpython39:python}"
 [[lift.bindings]]
 name = "install"
 description = """\
-Installs a hermetic Pants environment from PyPI or binaries.pantsbuild.org with optional debug \
-support.\
+Installs a hermetic Pants environment from PyPI, binaries.pantsbuild.org, or a GitHub release \
+with optional debug support.\
 """
 exe = "#{cpython:python}"
 args = [
@@ -218,6 +218,8 @@ args = [
     "{scie.env.PANTS_DEBUG}",
     "--debugpy-requirement",
     "{scie.env.PANTS_DEBUGPY_VERSION}",
+    "--ptex-path",
+    "{ptex}",
     "{scie.bindings}",
 ]
 env.remove_re = [

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -415,9 +415,11 @@ fn test_pants_from_pex_version(scie_pants_scie: &Path) {
             .current_dir(&tmpdir)
             .stdout(Stdio::piped()),
     );
-    assert_eq!(
-        pants_release,
-        decode_output(output.unwrap().stdout).unwrap().trim()
+    let expected_message = pants_release;
+    let stdout = decode_output(output.unwrap().stdout).unwrap();
+    assert!(
+        stdout.contains(expected_message),
+        "STDOUT did not contain '{expected_message}':\n{stdout}"
     );
 }
 

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -624,7 +624,7 @@ fn test_delegate_pants_in_pants_repo(scie_pants_scie: &Path, pants_2_14_1_clone_
 }
 
 fn test_use_pants_release_in_pants_repo(scie_pants_scie: &Path, pants_2_14_1_clone_dir: &PathBuf) {
-    let pants_release = "2.16.0.dev5";
+    let pants_release = "2.16.0rc2";
     integration_test!("Verify usage of Pants {pants_release} on the pants repo.");
     let output = assert_stderr_output(
         Command::new(scie_pants_scie)

--- a/tools/src/scie_pants/configure_pants.py
+++ b/tools/src/scie_pants/configure_pants.py
@@ -86,6 +86,7 @@ def main() -> NoReturn:
         resolve_info = determine_sha_version(
             ptex=ptex, sha=options.pants_sha, find_links_dir=find_links_dir
         )
+        assert resolve_info.sha_version is not None
         version = resolve_info.sha_version
     elif options.pants_version:
         resolve_info = determine_tag_version(
@@ -122,10 +123,11 @@ def main() -> NoReturn:
         finalizer()
 
     with open(env_file, "a") as fp:
-        print(f"FIND_LINKS={resolve_info.find_links}", file=fp)
+        if resolve_info.find_links:
+            print(f"FIND_LINKS={resolve_info.find_links}", file=fp)
+            print(f"PANTS_SHA_FIND_LINKS={resolve_info.pants_find_links_option(version)}", file=fp)
         if newly_created_build_root:
             print(f"PANTS_BUILDROOT_OVERRIDE={newly_created_build_root}", file=fp)
-        print(f"PANTS_SHA_FIND_LINKS={resolve_info.pants_find_links_option(version)}", file=fp)
         print(f"PANTS_VERSION={version}", file=fp)
         print(f"PYTHON={python}", file=fp)
 

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -92,11 +92,12 @@ def install_pants_from_pex(
         except subprocess.CalledProcessError as e:
             fatal(
                 f"Wasn't able to fetch the Pants PEX at {pex_url}.\n\n"
-                + "Check to see if the URL is reachable (i.e. GitHub isn't down) and if the asset exists."
-                + " If the asset doesn't exist it may be that this platform isn't yet supported."
-                + " If that's the case, please reach out on Slack: https://www.pantsbuild.org/docs/getting-help#slack"
-                + " or file an issue on GitHub: https://github.com/pantsbuild/pants/issues/new/choose.\n\n"
-                + f"Exception:\n\n{e}"
+                "Check to see if the URL is reachable (i.e. GitHub isn't down) and if"
+                f" {pex_name} asset exists within the release: https://github.com/pantsbuild/pants/releases/release_{version}."
+                " If the asset doesn't exist it may be that this platform isn't yet supported."
+                " If that's the case, please reach out on Slack: https://www.pantsbuild.org/docs/getting-help#slack"
+                " or file an issue on GitHub: https://github.com/pantsbuild/pants/issues/new/choose.\n\n"
+                f"Exception:\n\n{e}"
             )
         subprocess.run(
             args=[

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -108,7 +108,8 @@ def install_pants_from_pex(
                 "--compile",
                 "--pip",
                 "--collisions-ok",
-                # @TODO: Remove pex? --rm pex
+                "--no-emit-warnings",  # Silence `PEXWarning: You asked for --pip ...`
+                "--disable-cache",
                 str(venv_dir),
             ],
             env={"PEX_TOOLS": "1"},

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 # After this version, Pants is released as a per-platform PEX using GitHub Release assets.
 # See https://github.com/pantsbuild/pants/pull/19450
-PANTS_PEX_GITHUB_RELEASE_VERSION = Version("2.18.0.dev3")
+PANTS_PEX_GITHUB_RELEASE_VERSION = Version("2.18.0.dev5")
 
 
 @dataclass(frozen=True)

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -18,19 +18,27 @@ import tomlkit
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from scie_pants.log import info, warn
+from scie_pants.log import fatal, info, warn
 from scie_pants.ptex import Ptex
 
 log = logging.getLogger(__name__)
+
+# After this version, Pants is released as a per-platform PEX using GitHub Release assets.
+# See https://github.com/pantsbuild/pants/pull/19450
+PANTS_PEX_GITHUB_RELEASE_VERSION = Version("2.18.0.dev3")
 
 
 @dataclass(frozen=True)
 class ResolveInfo:
     stable_version: Version
-    sha_version: Version
-    find_links: str
+    sha_version: Version | None
+    find_links: str | None
 
     def pants_find_links_option(self, pants_version_selected: Version) -> str:
+        assert (
+            self.find_links is not None
+        ), "pants_find_links_option shouldn't be called if find_links is None"
+
         # We only want to add the find-links repo for PANTS_SHA invocations so that plugins can
         # resolve Pants the only place it can be found in that case - our ~private
         # binaries.pantsbuild.org S3 find-links bucket.
@@ -88,6 +96,10 @@ def determine_find_links(
 def determine_tag_version(
     ptex: Ptex, pants_version: str, find_links_dir: Path, github_api_bearer_token: str | None = None
 ) -> ResolveInfo:
+    stable_version = Version(pants_version)
+    if stable_version >= PANTS_PEX_GITHUB_RELEASE_VERSION:
+        return ResolveInfo(stable_version, sha_version=None, find_links=None)
+
     tag = f"release_{pants_version}"
 
     # N.B.: The tag database was created with the following in a Pants clone:

--- a/tools/src/scie_pants/ptex.py
+++ b/tools/src/scie_pants/ptex.py
@@ -45,5 +45,5 @@ class Ptex:
     def fetch_text(self, url: str, **headers: str) -> str:
         return self._fetch(url, stdout=subprocess.PIPE, **headers).stdout.decode()
 
-    def fetch_to_fp(self, url: str, fp: IO, **headers: str) -> None:
+    def fetch_to_fp(self, url: str, fp: IO[bytes], **headers: str) -> None:
         self._fetch(url, stdout=fp.fileno(), **headers)

--- a/tools/src/scie_pants/ptex.py
+++ b/tools/src/scie_pants/ptex.py
@@ -9,7 +9,7 @@ import subprocess
 from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass
 from subprocess import CompletedProcess
-from typing import Any, BinaryIO, Callable, cast
+from typing import IO, Any, Callable, cast
 
 
 @dataclass(frozen=True)
@@ -45,5 +45,5 @@ class Ptex:
     def fetch_text(self, url: str, **headers: str) -> str:
         return self._fetch(url, stdout=subprocess.PIPE, **headers).stdout.decode()
 
-    def fetch_to_fp(self, url: str, fp: BinaryIO, **headers: str) -> None:
+    def fetch_to_fp(self, url: str, fp: IO, **headers: str) -> None:
         self._fetch(url, stdout=fp.fileno(), **headers)


### PR DESCRIPTION
This change makes it so `scie-pants` will create the Pants venv using the per-platform PEX uploaded to the release (for Pants releases). 

As a result, it bypasses the `--find-links` support that was otherwise required, so a few tweaks were made to allow that.

Additionally, we still install `debugpy` ad-hoc into the venv if required.

---

Using this repo, setting the version to `2.18.0.dev5`

```console
josh@cephandrius:~/work/scie-pants$ cargo run -p package -- scie
josh@cephandrius:~/work/scie-pants$ rm -rf /home/josh/.cache/nce/5b2404164fc1c3e3a34d18a5da428b73e51c82e6b5a7a020d563cb9bb1a9db20
josh@cephandrius:~/work/scie-pants$ dist/scie-pants-linux-x86_64 --version --no-verify-config
... (specifically I see it downloading the PEX)
New virtual environment successfully created at /home/josh/.cache/nce/0a5efe87c1f41645e4c37ec0402c76133d73a1246f35d59432dad968e1977d99/bindings/venvs/2.18.0.dev5.
2.18.0.dev5
```