### PR TITLE
Propagate scie-pants' version into the pants invocation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,20 @@
 # Release Notes
 
-## 0.9.0
+## 0.9.2
+
+This release propagates the version of the `scie-pants` into the invocation of pants, so that Pants
+itself can [detect if it requires (or will require) features from newer versions of
+`scie-pants`](https://github.com/pantsbuild/pants/issues/19600).
+
+## 0.9.0 / 0.9.1
 
 This release adds support for scie-pants to bootstrap Pants using a "per-platform" PEX uploaded as
 a GitHub release asset. Additionally, the new wheels.pantsbuild.prg/simple wheels index has been wired
 up to support Pants releases back to 2.0.0.dev0. Lastly, the selection of the latest version is now
 deferred to the GitHub Release with the "latest" tag.
+
+NB. this version was published as 0.9.0, but `PANTS_BOOTSTRAP_VERSION=report pants` reports itself
+as 0.9.1.
 
 ## 0.8.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,7 @@ fn get_pants_from_sources_process(pants_repo_location: PathBuf) -> Result<Proces
             build_root.as_os_str().to_os_string(),
         ),
         ("no_proxy".into(), "*".into()),
+        ("SCIE_PANTS_VERSION".into(), SCIE_PANTS_VERSION.into()),
     ];
 
     Ok(Process { exe, args, env })

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ use crate::config::PantsConfig;
 mod build_root;
 mod config;
 
+const SCIE_PANTS_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Debug, Default)]
 struct Process {
     exe: OsString,
@@ -221,6 +223,7 @@ fn get_pants_process() -> Result<Process> {
             "PANTS_DEBUG".into(),
             if pants_debug { "1" } else { "" }.into(),
         ),
+        ("SCIE_PANTS_VERSION".into(), SCIE_PANTS_VERSION.into()),
     ];
     if let Some(debugpy_version) = debugpy_version {
         env.push(("PANTS_DEBUGPY_VERSION".into(), debugpy_version.into()));
@@ -313,7 +316,7 @@ fn main() -> Result<()> {
     // scie-pants available.
     if let Ok(value) = env::var("PANTS_BOOTSTRAP_VERSION") {
         if "report" == value.as_str() {
-            println!(env!("CARGO_PKG_VERSION"));
+            println!("{}", SCIE_PANTS_VERSION);
             std::process::exit(0);
         }
     }


### PR DESCRIPTION
This sets the `SCIE_PANTS_VERSION` env var when invoking pants, so that pants can read it and encourage users to upgrade if they need to.

For example, 2.17 will be the last release that supports the PyPI-based distribution model and Pants 2.18 will require scie-pants 0.9 or greater. So, in https://github.com/pantsbuild/pants/issues/19600, we're planning to have pants 2.17 encourage users to upgrade `scie-pants` if it's too old.

This PR preps for the release too, by bumping the version and adding a changelog entry. As part of this, I noticed the 0.9.0 release was accidentally configured as 0.9.1 in Cargo.toml, so updated the changelog to mention this.