### PR TITLE
Bump to 0.9.3, due to tagging mistake

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,14 @@
 # Release Notes
 
-## 0.9.2
+## 0.9.3
 
 This release propagates the version of the `scie-pants` into the invocation of pants, so that Pants
 itself can [detect if it requires (or will require) features from newer versions of
 `scie-pants`](https://github.com/pantsbuild/pants/issues/19600).
+
+## 0.9.2
+
+Skipped due to a release error.
 
 ## 0.9.0 / 0.9.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",


### PR DESCRIPTION
I tagged the wrong commit for releasing 0.9.2 (fdceed643f34e818f7095b2b4bf4f1f78b95bbf7, instead of the e52a6d3fc8fb1eda6cc015102196d015b98c534a for #246), sooo... this skips 0.9.2 and preps to release 0.9.3 instead. Maybe I'll get it right this time.

I cancelled the build for 0.9.2, because that'd be confusing.