### PR TITLE
Pass --python-repos-find-links always, and deprecate PANTS_SHA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## 0.10.0
+
+This release deprecates support for running against an arbitrary Pants commit using
+`PANTS_SHA=abc123... pants ...`. Pants no longer
+publishes the artifacts required for this for new commits, and so this is becoming less and less
+useful. To replace use of `PANTS_SHA`, do one of:
+
+- Use a released version of Pants.
+- Run pants from sources (for example: `PANTS_SOURCE=/path/to/pants-checkout pants ...`).
+- If these are not appropriate, [let us know what you're using it for](https://www.pantsbuild.org/docs/getting-help).
+
+
+This release also fixes scie-pants running commands like `pants tailor --check ...` with Pants
+2.18.0.dev5 and newer (releases that use the new "per-platform" PEX).
+
 ## 0.9.3
 
 This release propagates the version of the `scie-pants` into the invocation of pants, so that Pants

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.9.3"
+version = "0.10.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
 use build_root::BuildRoot;
-use log::{info, trace};
+use log::{info, trace, warn};
 use logging_timer::{time, timer, Level};
 use uuid::Uuid;
 
@@ -173,11 +173,19 @@ fn get_pants_process() -> Result<Process> {
 
     let env_pants_sha = env_version("PANTS_SHA")?;
     let env_pants_version = env_version("PANTS_VERSION")?;
-    if let (Some(pants_sha), Some(pants_version)) = (&env_pants_sha, &env_pants_version) {
-        bail!(
-            "Both PANTS_SHA={pants_sha} and PANTS_VERSION={pants_version} were set. \
-            Please choose one.",
-        )
+    if let Some(pants_sha) = &env_pants_sha {
+        // when support for PANTS_SHA is fully removed, PANTS_SHA_FIND_LINKS can be removed too
+        warn!(
+            "DEPRECATED: Support for PANTS_SHA={pants_sha} will be removed in a future version of the `pants` launcher. \
+            In addition, the artifacts for PANTS_SHA are no longer published for new commits. Use a released version."
+        );
+
+        if let Some(pants_version) = &env_pants_version {
+            bail!(
+                "Both PANTS_SHA={pants_sha} and PANTS_VERSION={pants_version} were set. \
+                Please choose one.",
+            )
+        }
     }
 
     let pants_version = if let Some(env_version) = env_pants_version {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
 use build_root::BuildRoot;
-use log::{info, trace, warn};
+use log::{info, trace};
 use logging_timer::{time, timer, Level};
 use uuid::Uuid;
 
@@ -175,9 +175,10 @@ fn get_pants_process() -> Result<Process> {
     let env_pants_version = env_version("PANTS_VERSION")?;
     if let Some(pants_sha) = &env_pants_sha {
         // when support for PANTS_SHA is fully removed, PANTS_SHA_FIND_LINKS can be removed too
-        warn!(
-            "DEPRECATED: Support for PANTS_SHA={pants_sha} will be removed in a future version of the `pants` launcher. \
-            In addition, the artifacts for PANTS_SHA are no longer published for new commits. Use a released version."
+        eprintln!(
+            "DEPRECATED: Support for PANTS_SHA=... will be removed in a future version of the `pants` launcher.\
+             \n\nYou've set PANTS_SHA={pants_sha}. The artifacts for PANTS_SHA are no longer published for new commits. \
+             To resolve, use a released version, and/or let us know about what you're doing at <https://www.pantsbuild.org/docs/getting-help>.\n"
         );
 
         if let Some(pants_version) = &env_pants_version {

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,9 +176,16 @@ fn get_pants_process() -> Result<Process> {
     if let Some(pants_sha) = &env_pants_sha {
         // when support for PANTS_SHA is fully removed, PANTS_SHA_FIND_LINKS can be removed too
         eprintln!(
-            "DEPRECATED: Support for PANTS_SHA=... will be removed in a future version of the `pants` launcher.\
-             \n\nYou've set PANTS_SHA={pants_sha}. The artifacts for PANTS_SHA are no longer published for new commits. \
-             To resolve, use a released version, and/or let us know about what you're doing at <https://www.pantsbuild.org/docs/getting-help>.\n"
+          "\
+DEPRECATED: Support for PANTS_SHA=... will be removed in a future version of the `pants` launcher.
+
+The artifacts for PANTS_SHA are no longer published for new commits. This invocation set PANTS_SHA={pants_sha}.
+
+To resolve, do one of:
+- Use a released version of Pants.
+- Run pants from sources (for example: `PANTS_SOURCE=/path/to/pants-checkout pants ...`).
+- If these are not appropriate, let us know what you're using it for: <https://www.pantsbuild.org/docs/getting-help>.
+"
         );
 
         if let Some(pants_version) = &env_pants_version {

--- a/tools/src/scie_pants/configure_pants.py
+++ b/tools/src/scie_pants/configure_pants.py
@@ -125,7 +125,9 @@ def main() -> NoReturn:
     with open(env_file, "a") as fp:
         if resolve_info.find_links:
             print(f"FIND_LINKS={resolve_info.find_links}", file=fp)
-            print(f"PANTS_SHA_FIND_LINKS={resolve_info.pants_find_links_option(version)}", file=fp)
+        # This can be removed once we stop supporting PANTS_SHA:
+        # NB. this is added unconditionally because it gets set as an argument
+        print(f"PANTS_SHA_FIND_LINKS={resolve_info.pants_find_links_option(version)}", file=fp)
         if newly_created_build_root:
             print(f"PANTS_BUILDROOT_OVERRIDE={newly_created_build_root}", file=fp)
         print(f"PANTS_VERSION={version}", file=fp)

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -38,10 +38,6 @@ class ResolveInfo:
     find_links: str | None
 
     def pants_find_links_option(self, pants_version_selected: Version) -> str:
-        assert (
-            self.find_links is not None
-        ), "pants_find_links_option shouldn't be called if find_links is None"
-
         # We only want to add the find-links repo for PANTS_SHA invocations so that plugins can
         # resolve Pants the only place it can be found in that case - our ~private
         # binaries.pantsbuild.org S3 find-links bucket.
@@ -51,7 +47,11 @@ class ResolveInfo:
             if self.stable_version in SpecifierSet("<2.14.0", prereleases=True)
             else "find-links"
         )
-        return f"--python-repos-{option_name}={operator}['{self.find_links}']"
+        value = f"'{self.find_links}'" if self.find_links else ''
+
+        # we usually pass a no-op, e.g. --python-repos-find-links=-[], because this is only used for
+        # PANTS_SHA support that is now deprecated and will be removed
+        return f"--python-repos-{option_name}={operator}[{value}]"
 
 
 def determine_find_links(

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -47,7 +47,7 @@ class ResolveInfo:
             if self.stable_version in SpecifierSet("<2.14.0", prereleases=True)
             else "find-links"
         )
-        value = f"'{self.find_links}'" if self.find_links else ''
+        value = f"'{self.find_links}'" if self.find_links else ""
 
         # we usually pass a no-op, e.g. --python-repos-find-links=-[], because this is only used for
         # PANTS_SHA support that is now deprecated and will be removed


### PR DESCRIPTION
Currently, the `scie-pants` launcher sometimes needs to pass an additional argument to the underlying pants invocation, to be able to support `PANTS_SHA` and its custom wheel location. Effectively turning an invocation like `pants goal --arg` into `pants --pants-repos-find-links=+["..."] goal --arg` when appropriate: https://github.com/pantsbuild/scie-pants/blob/0a204c5ac816ad24d74b55ecf7424397a07b3c2a/package/scie-pants.toml#L57-L60

However, when not using `PANTS_SHA`, the pants command becomes `pants "" goal --arg`, and the spurious empty string results in some commands failing, e.g. `pants "" tailor --check` thinks `--check` is a global argument, and this is ambiguous.

To fix this issue, this PR does two things:

1. avoid passing an empty string, via a no-op workaround: always set the `PANTS_SHA_FIND_LINKS` variable (to a no-op like `--python-repos-find-links=-[]`), so that scie-pants never passes an empty variable to the pants command, since that makes commands like `pants tailor --check ::` explode:
2. deprecates `PANTS_SHA`, so that the hack above doesn't feel so bad: we're on the way to removing the need for `PANTS_SHA_FIND_LINKS` entirely, thus sidestepping the limitation and the need for the workaround (2)

This could also be fixed via https://github.com/a-scie/jump/issues/130.

Fixes #249