### PR TITLE
Run `tailor --check update-build-files --check` in CI too

### DIFF
--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -170,7 +170,17 @@ fn test_tools(scie_pants_scie: &Path, check: bool) {
     }
     execute(
         command
-            .args(["lint", "check", "test", "package", "::"])
+            .args([
+                "tailor",
+                "--check",
+                "update-build-files",
+                "--check",
+                "lint",
+                "check",
+                "test",
+                "package",
+                "::",
+            ])
             .env("PEX_SCRIPT", "Does not exist!")
             .env("EXPECTED_COLUMNS", tput_output("cols").trim())
             .env("EXPECTED_LINES", tput_output("lines").trim()),

--- a/tools/src/scie_pants.dist-info/BUILD
+++ b/tools/src/scie_pants.dist-info/BUILD
@@ -5,6 +5,4 @@
 # and the `cargo run -p package -- tools` command. The latter uses `pex -D tools/src` which picks up
 # these BUILDs. Moving these targets to `tools/BUILD` would solve that problem but causes Pants
 # issues since the targets contained within are then above the `tools/src` source root.
-resources(
-    sources=["**/*"]
-)
+resources(sources=["**/*"])

--- a/tools/tests/BUILD
+++ b/tools/tests/BUILD
@@ -6,9 +6,7 @@ python_test_utils(
 )
 
 python_tests(
-    runtime_package_dependencies=[
-        "//tools"
-    ],
+    runtime_package_dependencies=["//tools"],
     extra_env_vars=[
         "COLUMNS",
         "EXPECTED_COLUMNS",


### PR DESCRIPTION
This adds to the pants test to run `tailor --check update-build-files --check` too, because there were some BUILD files with incorrect formatting.