### PR TITLE
Consume versioned PEX releases

### DIFF
--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -82,11 +82,11 @@ def install_pants_from_pex(
     """Installs Pants into the venv using the platform-specific pre-built PEX."""
     uname = os.uname()
     major, minor = sys.version_info[:2]
-    pex_name = f"pants.cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}.pex"
+    pex_name = (
+        f"pants.{version}-cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}.pex"
+    )
+    pex_url = f"https://github.com/pantsbuild/pants/releases/download/release_{version}/{pex_name}"
     with tempfile.NamedTemporaryFile(suffix=".pex") as pants_pex:
-        pex_url = (
-            f"https://github.com/pantsbuild/pants/releases/download/release_{version}/{pex_name}"
-        )
         try:
             ptex.fetch_to_fp(pex_url, pants_pex.file)
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/19683 for the related Pantsbuild automation change.

This change makes it so we now consume PEX names with the expected Pants version in them.

This change isn't guarded by version, as I expect to backport this change to earlier releases.