### PR TITLE
Bust the existing CI cache.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.SCIE_PANTS_DEV_CACHE }}
-          key: ${{ matrix.os }}-scie-pants-v5
+          key: ${{ matrix.os }}-scie-pants-v6
       - name: Build, Package & Integration Tests
         if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64'}}
         run: |


### PR DESCRIPTION
Works around #270 for now, until we fix it more robustly.