### PR TITLE
avoid printing Pants Python version to the console

### DIFF
--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -176,7 +176,8 @@ def main() -> NoReturn:
 
     version = options.pants_version
     python_version = ".".join(map(str, sys.version_info[:3]))
-    debug(f"Bootstrapping Pants {version} using {sys.implementation.name} {python_version}")
+    info(f"Bootstrapping Pants {version}")
+    debug(f"Pants itself is using: {sys.implementation.name} {python_version}")
 
     pants_requirements = [f"pantsbuild.pants=={version}"]
     extra_requirements = []

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -17,7 +17,7 @@ from typing import Iterable, NoReturn
 
 from packaging.version import Version
 
-from scie_pants.log import fatal, info, init_logging
+from scie_pants.log import debug, fatal, info, init_logging
 from scie_pants.pants_version import PANTS_PEX_GITHUB_RELEASE_VERSION
 from scie_pants.ptex import Ptex
 
@@ -176,7 +176,7 @@ def main() -> NoReturn:
 
     version = options.pants_version
     python_version = ".".join(map(str, sys.version_info[:3]))
-    info(f"Bootstrapping Pants {version} using {sys.implementation.name} {python_version}")
+    debug(f"Bootstrapping Pants {version} using {sys.implementation.name} {python_version}")
 
     pants_requirements = [f"pantsbuild.pants=={version}"]
     extra_requirements = []

--- a/tools/src/scie_pants/log.py
+++ b/tools/src/scie_pants/log.py
@@ -15,6 +15,10 @@ def _log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
+def debug(message: str) -> None:
+    logging.debug(message)
+
+
 def info(message: str) -> None:
     logging.info(message)
     _log(green(message))


### PR DESCRIPTION
This frequently causes onboarding confusion as the distinction between "the version of python pants uses" and "the version of python pants uses for my code uses" it not yet clear.  (And maybe should remain an implementation detail outside of plugin authors anyway.)