### PR TITLE
Update jump & science to improve error message for bad SCIE_BOOT

### DIFF
--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -8,7 +8,7 @@ Python Build Tool: A BusyBox that provides `python`, `pip`, `pex`, `pex3` and `p
 version = "0.7.0"
 
 [lift.scie-jump]
-version = "0.11.1"
+version = "0.13.0"
 
 [[lift.interpreters]]
 id = "cpython"

--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -7,7 +7,7 @@ Python Build Tool: A BusyBox that provides `python`, `pip`, `pex`, `pex3` and `p
 [lift.ptex]
 version = "0.7.0"
 
-[lift.scie-jump]
+[lift.scie_jump]
 version = "0.13.0"
 
 [[lift.interpreters]]

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -11,7 +11,7 @@ id = "ptex"
 version = "0.7.0"
 lazy_argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
 
-[lift.scie-jump]
+[lift.scie_jump]
 version = "0.13.0"
 
 [[lift.interpreters]]

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -12,7 +12,7 @@ version = "0.7.0"
 lazy_argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
 
 [lift.scie-jump]
-version = "0.11.1"
+version = "0.13.0"
 
 [[lift.interpreters]]
 id = "cpython38"
@@ -53,7 +53,9 @@ exe = "{scie-pants.bin}"
 # Run Pants
 [[lift.commands]]
 name = "pants"
-description = "Runs a hermetic Pants installation."
+# No description because this command shouldn't render in the help output (it's invoked as
+# appropriate by the default "Boot" one above)
+# description = "Runs a hermetic Pants installation."
 exe = "{scie.bindings.install:PANTS_CLIENT_EXE}"
 args = [
     "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}",
@@ -69,7 +71,9 @@ _PANTS_SERVER_EXE = "{scie.bindings.install:PANTS_SERVER_EXE}"
 # Run Pants Debug Mode
 [[lift.commands]]
 name = "pants-debug"
-description = "Runs a hermetic Pants installation with a debug server for debugging Pants code."
+# No description because this command shouldn't render in the help output (it's invoked as
+# appropriate by the default "Boot" one above)
+# description = "Runs a hermetic Pants installation with a debug server for debugging Pants code."
 exe = "{scie.bindings.install:VIRTUAL_ENV}/bin/pants"
 args = [
     "-c",

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -29,7 +29,7 @@ use crate::utils::fs::{base_name, canonicalize, copy, ensure_directory};
 
 const BINARY: &str = "scie-pants";
 
-const SCIENCE_TAG: &str = "v0.1.2";
+const SCIENCE_TAG: &str = "v0.2.1";
 
 #[derive(Clone)]
 struct SpecifiedPath(PathBuf);


### PR DESCRIPTION
This updates to jump to 0.13.0, which improves the error message for a bad `SCIE_BOOT` value. For example `SCIE_BOOT='update pants' pants` from https://pantsbuild.slack.com/archives/C046T6T9U/p1695047533069949 now shows:

```
Error: `SCIE_BOOT=update pants` was found in the environment but "update pants" does not correspond to any scie-pants commands.

Isolates your Pants from the elements.

Please select from the following boot commands:

<default> (when SCIE_BOOT is not set in the environment)  Detects the current Pants installation and launches it.
bootstrap-tools                                           Introspection tools for the Pants bootstrap process.
update                                                    Update scie-pants.

You can select a boot command by setting the SCIE_BOOT environment variable.
```

This also requires updating science to 0.2.1, for the `descriptions` to be propagated appropriately.