### PR TITLE
Update Cargo.lock for 0.10.2 bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "dirs",


### PR DESCRIPTION
This was missed from #288, oops!

In #290, I add the appropriate check to CI, to avoid this happening again.