### PR TITLE
Require Cargo.lock matches Cargo.toml in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           rustup toolchain add nightly -c rustfmt
           cargo +nightly fmt --check --all
       - name: Lint
-        run: cargo clippy --all
+        run: cargo clippy --locked --all
       - name: Unit Tests
         run: cargo test --all
       - name: Setup Python 3.9


### PR DESCRIPTION
This blocks the mistake I made in #288 / #289, where I updated `Cargo.toml` and forgot to run a command to update `Cargo.lock`.