### PR TITLE
Obey `PANTS_BOOTSTRAP_URLS` properly, update to science 0.2.2

### DIFF
--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -9,7 +9,7 @@ repo = "https://github.com/pantsbuild/scie-pants"
 [lift.ptex]
 id = "ptex"
 version = "0.7.0"
-lazy_argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
+argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
 
 [lift.scie_jump]
 version = "0.13.0"
@@ -40,7 +40,7 @@ members = [
 # N.B.: We name the scie-pants binary scie-pants.bin since the scie itself is named scie-pants
 # which would conflict when packaging.
 name = "scie-pants.bin"
-executable = true
+is_executable = true
 
 [[lift.files]]
 name = "tools.pex"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -40,7 +40,6 @@ members = [
 # N.B.: We name the scie-pants binary scie-pants.bin since the scie itself is named scie-pants
 # which would conflict when packaging.
 name = "scie-pants.bin"
-is_executable = true
 
 [[lift.files]]
 name = "tools.pex"

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -29,7 +29,7 @@ use crate::utils::fs::{base_name, canonicalize, copy, ensure_directory};
 
 const BINARY: &str = "scie-pants";
 
-const SCIENCE_TAG: &str = "v0.2.1";
+const SCIENCE_TAG: &str = "v0.2.2";
 
 #[derive(Clone)]
 struct SpecifiedPath(PathBuf);


### PR DESCRIPTION
This updates to https://github.com/a-scie/lift/releases/tag/v0.2.2, which has diagnostics to detect invalid/ignored entries in the configuration files. This detects two:

- the `scie-pants.bin` file wasn't being marked as executable properly... which suggests it doesn't need to be
- the `PANTS_BOOTSTRAP_URLS` env var wasn't being passed through to `ptex` properly, and thus redirecting the downloads wasn't working as intended.

Fixes #243 