### PR TITLE
Upgrade to Pants 2.17

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.16.0"
+pants_version = "2.17.0"
 
 backend_packages = [
     "pants.backend.python",
@@ -24,6 +24,9 @@ resolves_generate_lockfiles = false
 
 [python.resolves]
 python-default = "tools/lock.json"
+
+[python-infer]
+use_rust_parser = true
 
 [pex-cli]
 version = "v2.1.137"


### PR DESCRIPTION
This upgrades scie-pants' internal use of Pants to 2.17.

Setting `use_rust_parser = true` gave the same `pants peek ::` output as without ✅ 