### PR TITLE
Test firewall support, make doc section linkable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +465,7 @@ dependencies = [
  "once_cell",
  "pretty_env_logger",
  "regex",
+ "serde_json",
  "sha2",
  "tempfile",
  "termcolor",
@@ -592,6 +599,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +648,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.29",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ under a top-level `"ptex"` key. For example:
     "cpython-3.8.16+20230507-aarch64-apple-darwin-install_only.tar.gz": "https://example.com/cpython-3.8.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
     "cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz": "https://example.com/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
     "cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz": "https://example.com/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
-    "pants.2.18.0-cp9-linux-x86_64.pex": "https://example.com/pants.2.18.0-cp9-linux-x86_64.pex",
+    "pants.2.18.0-cp39-linux_x86_64.pex": "https://example.com/pants.2.18.0-cp39-linux_x86_64.pex",
     ...
   }
 }
@@ -100,7 +100,7 @@ the hash mismatch.
 
 For other keys that aren't embedded, and are generated on-the-fly (such as the Pants PEX), there
 is no single source of truth that can be easily scraped out. For the Pants PEX, the key is the versioned
-PEX name (E.g. `pants.<version>-<python>-<plat>-<machine>.pex`). These can be found on the relevant
+PEX name (E.g. `pants.<version>-<python>-<plat>_<machine>.pex`). These can be found on the relevant
 GitHub Release page's Assets (e.g. https://github.com/pantsbuild/pants/releases/tag/release_2.18.0a0).
 (Note that for 2.18.x, PEX exist versioned and unversioned. `scie-pants` only uses the versioned
 name as the key).

--- a/README.md
+++ b/README.md
@@ -60,48 +60,50 @@ provides the following:
   `scie-pants` executable to `pants_from_sources` and execute that. In this case `PANTS_SOURCE` will
   default to `../pants` just as was the case in the bespoke `./pants_from_sources` scripts.
 
-+ Partial support for firewalls:
++ Partial support for firewalls
 
-  Currently, you can re-direct the URLs used to fetch:
+### Firewall support
 
-    + [Python Build Standalone](https://python-build-standalone.readthedocs.io/en/latest/) CPython
-      distributions used to bootstrap Pants.
-    + Pants PEX release assets which contain Pants as a single-file application.
+Currently, you can re-direct the URLs used to fetch:
 
-  This is done by exporting a `PANTS_BOOTSTRAP_URLS` environment variable
-  specifying the path to a JSON file containing a mapping of file names to URLS to fetch them from
-  under a top-level `"ptex"` key. For example:
-  ```json
-  {
-    "ptex": {
-      "cpython-3.8.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz": "https://example.com/cpython-3.8.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
-      "cpython-3.8.16+20230507-aarch64-apple-darwin-install_only.tar.gz": "https://example.com/cpython-3.8.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
-      "cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz": "https://example.com/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
-      "cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz": "https://example.com/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
-      "pants.2.18.0-cp9-linux-x86_64.pex": "https://example.com/pants.2.18.0-cp9-linux-x86_64.pex",
-      ...
-    }
+  + [Python Build Standalone](https://python-build-standalone.readthedocs.io/en/latest/) CPython
+    distributions used to bootstrap Pants.
+  + Pants PEX release assets which contain Pants as a single-file application.
+
+This is done by exporting a `PANTS_BOOTSTRAP_URLS` environment variable
+specifying the path to a JSON file containing a mapping of file names to URLS to fetch them from
+under a top-level `"ptex"` key. For example:
+```json
+{
+  "ptex": {
+    "cpython-3.8.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz": "https://example.com/cpython-3.8.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    "cpython-3.8.16+20230507-aarch64-apple-darwin-install_only.tar.gz": "https://example.com/cpython-3.8.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
+    "cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz": "https://example.com/cpython-3.9.16%2B20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
+    "cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz": "https://example.com/cpython-3.9.16%2B20230507-aarch64-apple-darwin-install_only.tar.gz",
+    "pants.2.18.0-cp9-linux-x86_64.pex": "https://example.com/pants.2.18.0-cp9-linux-x86_64.pex",
+    ...
   }
-  ```
+}
+```
 
-  For keys that are "embedded" into `scie-pants` itself (such as Python Build Standalone), you can run:
-  ```
-  $ SCIE=inspect scie-pants | jq .ptex
-  ```
-  You'll need to run this once for each platform you use `scie-pants` on to gather all mappings
-  you'll need; e.g.: once for Linux x86_64 and once for Mac ARM.
+For keys that are "embedded" into `scie-pants` itself (such as Python Build Standalone), you can run:
+```
+$ SCIE=inspect scie-pants | jq .ptex
+```
+You'll need to run this once for each platform you use `scie-pants` on to gather all mappings
+you'll need; e.g.: once for Linux x86_64 and once for Mac ARM.
 
-  The embedded artifact references also contain expected hashes of the downloaded content. Your
-  re-directed URLs must provide the same content as the canonical URLs; if the hashes of downloaded
-  files do not match those recorded in `scie-pants`, install will fail fast and let you know about
-  the hash mismatch.
+The embedded artifact references also contain expected hashes of the downloaded content. Your
+re-directed URLs must provide the same content as the canonical URLs; if the hashes of downloaded
+files do not match those recorded in `scie-pants`, install will fail fast and let you know about
+the hash mismatch.
 
-  For other keys that aren't embedded, and are generated on-the-fly (such as the Pants PEX), there
-  is no single source of truth that can be easily scraped out. For the Pants PEX, the key is the versioned
-  PEX name (E.g. `pants.<version>-<python>-<plat>-<machine>.pex`). These can be found on the relevant
-  GitHub Release page's Assets (e.g. https://github.com/pantsbuild/pants/releases/tag/release_2.18.0a0).
-  (Note that for 2.18.x, PEX exist versioned and unversioned. `scie-pants` only uses the versioned
-  name as the key).
+For other keys that aren't embedded, and are generated on-the-fly (such as the Pants PEX), there
+is no single source of truth that can be easily scraped out. For the Pants PEX, the key is the versioned
+PEX name (E.g. `pants.<version>-<python>-<plat>-<machine>.pex`). These can be found on the relevant
+GitHub Release page's Assets (e.g. https://github.com/pantsbuild/pants/releases/tag/release_2.18.0a0).
+(Note that for 2.18.x, PEX exist versioned and unversioned. `scie-pants` only uses the versioned
+name as the key).
 
 ## Caveats
 

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -18,6 +18,7 @@ log = { workspace = true }
 once_cell = "1.18"
 pretty_env_logger = "0.5"
 regex = "1.9"
+serde_json = "1.0.107"
 sha2 = "0.10"
 tempfile = { workspace = true }
 termcolor = "1.3"


### PR DESCRIPTION
This adds a test for #243 (which could've/should've been in #293). It also tweaks the documentation to put the "firewall support" docs in their own section, so that it can be directly linked more easily.

The commits are individually reviewable.