### PR TITLE
Prepare 0.10.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 0.10.3
+
+This release ensures scie-pants obeys the `PANTS_BOOTSTRAP_URLS` environment variable. This
+environment variable can be set to the path of JSON file, and (now) allows overriding the default
+locations from which scie-pants fetches Python interpreters and Pants PEXes, to [support
+firewalls](https://github.com/pantsbuild/scie-pants#firewall-support).
+
 ## 0.10.2
 
 This release improves diagnostics and logging.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",


### PR DESCRIPTION
The only user-visible feature is #293, plus the doc changes in #296. There's various (hopefully, internal-only) dependency upgrades and similar.

Full changes: https://github.com/pantsbuild/scie-pants/compare/v0.10.2...91477f6394e8eed048e093538b4a4c299514e44f

([This time](https://github.com/pantsbuild/scie-pants/pull/289), I remembered to bump `Cargo.lock`.)