### PR TITLE
Fix regression for `pants-debug` boot mode.

### DIFF
--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -73,7 +73,7 @@ name = "pants-debug"
 # No description because this command shouldn't render in the help output (it's invoked as
 # appropriate by the default "Boot" one above)
 # description = "Runs a hermetic Pants installation with a debug server for debugging Pants code."
-exe = "{scie.bindings.install:VIRTUAL_ENV}/bin/pants"
+exe = "{scie.bindings.install:VIRTUAL_ENV}/bin/python"
 args = [
     "-c",
     """\


### PR DESCRIPTION
Fixes a typo from 0ebe82ac69be11c6c2537a9f3615f3c0e84a67ea.

Closes #309 
