### PR TITLE
Bump the bundled PBS versions to `20231002`.

### DIFF
--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -13,9 +13,9 @@ version = "0.13.0"
 [[lift.interpreters]]
 id = "cpython"
 provider = "PythonBuildStandalone"
-release = "20230507"
+release = "20231002"
 lazy = true
-version = "3.8.16"
+version = "3.8.18"
 
 [[lift.files]]
 name = "pex"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -17,16 +17,16 @@ version = "0.13.0"
 [[lift.interpreters]]
 id = "cpython38"
 provider = "PythonBuildStandalone"
-release = "20230507"
+release = "20231002"
 lazy = true
-version = "3.8.16"
+version = "3.8.18"
 
 [[lift.interpreters]]
 id = "cpython39"
 provider = "PythonBuildStandalone"
-release = "20230507"
+release = "20231002"
 lazy = true
-version = "3.9.16"
+version = "3.9.18"
 
 [[lift.interpreter_groups]]
 id = "cpython"

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -1189,7 +1189,7 @@ fn test_pants_bootstrap_urls(scie_pants_scie: &Path) {
         }
     });
 
-    let output = execute(&mut command.stdout(Stdio::piped())).unwrap();
+    let output = execute(command.stdout(Stdio::piped())).unwrap();
     let stdout = decode_output(output.stdout).unwrap();
     assert!(stdout.contains(pants_release));
 }


### PR DESCRIPTION
PBS release notes: https://github.com/indygreg/python-build-standalone/releases/tag/20231002

Additional context: a-scie/lift#38
