### PR TITLE
Update to scie jump 0.13.2, for errors on invalid .env

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 0.11.0
 
-This releases ensures that `scie-pants` emits an error if there's an `.env` file cannot be
+This release ensures that `scie-pants` emits an error if there's an `.env` file that cannot be
 understood, rather than silently ignoring the invalid contents (and everything after). In
 particular, `"`s are not supported, a line like `A="B C"` should be `A='B C'`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.11.0
+
+This releases ensures that `scie-pants` emits an error if there's an `.env` file cannot be
+understood, rather than silently ignoring the invalid contents (and everything after). In
+particular, `"`s are not supported, a line like `A="B C"` should be `A='B C'`.
+
 ## 0.10.4
 
 This release fixes a regression when using `PANTS_DEBUG`. The bundled Python interpreter has also

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.10.4"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.10.4"
+version = "0.11.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -8,7 +8,7 @@ Python Build Tool: A BusyBox that provides `python`, `pip`, `pex`, `pex3` and `p
 version = "0.7.0"
 
 [lift.scie_jump]
-version = "0.13.0"
+version = "0.13.2"
 
 [[lift.interpreters]]
 id = "cpython"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -12,7 +12,7 @@ version = "0.7.0"
 argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
 
 [lift.scie_jump]
-version = "0.13.0"
+version = "0.13.2"
 
 [[lift.interpreters]]
 id = "cpython38"


### PR DESCRIPTION
This fixes #307 by ensuring that an invalid `.env` file is flagged loudly, rather than silently ignored. This is done by updating scie jump to pick up https://github.com/a-scie/jump/issues/163 / https://github.com/a-scie/jump/pull/164 in https://github.com/a-scie/jump/releases/tag/v0.13.2 .

This is technically a breaking change, as someone may be using scie-pants fine, despite having an `.env` file lying around that's not understood by the underlying `dotenvy`. Thus, this is a bump to 0.11, rather than a patch to 0.10.