### PR TITLE
Add validation for pants_version format

### DIFF
--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -105,8 +105,15 @@ def install_pants_from_pex(
         try:
             ptex.fetch_to_fp(pex_url, pants_pex.file)
         except subprocess.CalledProcessError as e:
+            #  if there's only one dot in version, specifically suggest adding the `.patch`)
+            suggestion = (
+                "Pants version format not recognized. Please add `.<patch_version>` to the end of the version. For example: `2.18` -> `2.18.0`"
+                if version.base_version.count(".") < 2
+                else ""
+            )
             fatal(
                 f"Wasn't able to fetch the Pants PEX at {pex_url}.\n\n"
+                f"{suggestion}\n\n"
                 "Check to see if the URL is reachable (i.e. GitHub isn't down) and if"
                 f" {pex_name} asset exists within the release."
                 " If the asset doesn't exist it may be that this platform isn't yet supported."

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -107,13 +107,12 @@ def install_pants_from_pex(
         except subprocess.CalledProcessError as e:
             #  if there's only one dot in version, specifically suggest adding the `.patch`)
             suggestion = (
-                "Pants version format not recognized. Please add `.<patch_version>` to the end of the version. For example: `2.18` -> `2.18.0`"
+                "Pants version format not recognized. Please add `.<patch_version>` to the end of the version. For example: `2.18` -> `2.18.0`.\n\n"
                 if version.base_version.count(".") < 2
                 else ""
             )
             fatal(
-                f"Wasn't able to fetch the Pants PEX at {pex_url}.\n\n"
-                f"{suggestion}\n\n"
+                f"Wasn't able to fetch the Pants PEX at {pex_url}.\n\n{suggestion}"
                 "Check to see if the URL is reachable (i.e. GitHub isn't down) and if"
                 f" {pex_name} asset exists within the release."
                 " If the asset doesn't exist it may be that this platform isn't yet supported."

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -99,11 +99,6 @@ def determine_find_links(
 def determine_tag_version(
     ptex: Ptex, pants_version: str, find_links_dir: Path, github_api_bearer_token: str | None = None
 ) -> ResolveInfo:
-    # `pants_version` should be in the format `major.minor.micro`, e.g., `2.17.0`.
-    # Raise an error if it does not follow this format.
-    if not pants_version.count(".") == 2:
-        fatal(f"Expected a pants version like `major.minor.micro`, but got `{pants_version}`.\n\n")
-
     stable_version = Version(pants_version)
     if stable_version >= PANTS_PEX_GITHUB_RELEASE_VERSION:
         return ResolveInfo(stable_version, sha_version=None, find_links=None)

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -99,6 +99,11 @@ def determine_find_links(
 def determine_tag_version(
     ptex: Ptex, pants_version: str, find_links_dir: Path, github_api_bearer_token: str | None = None
 ) -> ResolveInfo:
+    # `pants_version` should be in the format `major.minor.micro`, e.g., `2.17.0`.
+    # Raise an error if it does not follow this format.
+    if not pants_version.count(".") == 2:
+        fatal(f"Expected a pants version like `major.minor.micro`, but got `{pants_version}`.\n\n")
+
     stable_version = Version(pants_version)
     if stable_version >= PANTS_PEX_GITHUB_RELEASE_VERSION:
         return ResolveInfo(stable_version, sha_version=None, find_links=None)


### PR DESCRIPTION
Implemented a check to ensure the 'pants_version' follows the 'major.minor.micro' format. This update raises a clear error message if the version string does not meet the expected format, enhancing user guidance and preventing configuration errors.

Fix #337 