### PR TITLE
Fix PBS linking against libcrypt.so.1 for real.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.10.6
+
+The bundled Python interpreter has been upgraded to release [`20240107`](
+https://github.com/indygreg/python-build-standalone/releases/tag/20240107) to avoid issues linking
+against missing `libcrypt.so.1` on Linux systems.
+
 ## 0.10.5
 
 This release upgrades the underlying version of scie-jump to 0.14.0, which provides the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -8,20 +8,20 @@ Python Build Tool: A BusyBox that provides `python`, `pip`, `pex`, `pex3` and `p
 version = "0.7.0"
 
 [lift.scie_jump]
-version = "0.13.0"
+version = "0.14.0"
 
 [[lift.interpreters]]
 id = "cpython"
 provider = "PythonBuildStandalone"
-release = "20231002"
+release = "20240107"
 lazy = true
 version = "3.8.18"
 
 [[lift.files]]
 name = "pex"
 type = "blob"
-digest = { size = 4098329, fingerprint = "faad51a6a108fba9d40b2a10e82a2646fccbaf8c3d9be47818f4bffae02d94b8" }
-source = { url = "https://github.com/pantsbuild/pex/releases/download/v2.1.137/pex", lazy = true }
+digest = { size = 3671772, fingerprint = "83c3090938b4d276703864c34ba50bcb3616db0663c54b56dd0521a668d9555f" }
+source = { url = "https://github.com/pantsbuild/pex/releases/download/v2.1.159/pex", lazy = true }
 
 [[lift.commands]]
 name = "pex"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -17,14 +17,14 @@ version = "0.14.0"
 [[lift.interpreters]]
 id = "cpython38"
 provider = "PythonBuildStandalone"
-release = "20231002"
+release = "20240107"
 lazy = true
 version = "3.8.18"
 
 [[lift.interpreters]]
 id = "cpython39"
 provider = "PythonBuildStandalone"
-release = "20231002"
+release = "20240107"
 lazy = true
 version = "3.9.18"
 

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -29,7 +29,7 @@ use crate::utils::fs::{base_name, canonicalize, copy, ensure_directory};
 
 const BINARY: &str = "scie-pants";
 
-const SCIENCE_TAG: &str = "v0.2.2";
+const SCIENCE_TAG: &str = "v0.3.1";
 
 #[derive(Clone)]
 struct SpecifiedPath(PathBuf);


### PR DESCRIPTION
The prior PBS upgrade was to a version that claimed to have this fixed,
but it was only fixed for 3.11 and not actually fixed for `3.{8,9,10}`.
This time we upgrade again to
https://github.com/indygreg/python-build-standalone/releases/tag/20240107
which notes this is actually now fixed for those Pythons. A manual test
of scie-pants 0.10.5 inside a fedora:37 container confirms the current
broken status and mounting in a freshly build scie-pants using this
change confirms a fix.

Fixes #52