### PR TITLE
Drop support for `PANTS_SHA`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: cargo clippy --locked --all
       - name: Unit Tests
         run: cargo test --all
-      - name: Setup Python 3.9
+      - name: Setup Python 3.9 (Ubuntu only)
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         uses: actions/setup-python@v4
         with:
@@ -54,9 +54,12 @@ jobs:
         with:
           path: ${{ env.SCIE_PANTS_DEV_CACHE }}
           key: ${{ matrix.os }}-scie-pants-v6
-      - name: Build, Package & Integration Tests
+      - name: Build, Package & Integration Tests (MacOS)
         if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64'}}
         run: |
+          # Clean up the science cache for Pants 2.19.1 setup to ensure it's bootstrapped each run.
+          rm -rf ~/Library/Caches/nce/*/bindings/venv/2.19.1
+
           # TODO(John Sirois): Kill --tools-pex-mismatch-warn:
           #   https://github.com/pantsbuild/scie-pants/issues/2
           #
@@ -69,7 +72,7 @@ jobs:
           #
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             cargo run -p package -- test --check --tools-pex-mismatch-warn
-      - name: Build, Package & Integration Tests
+      - name: Build, Package & Integration Tests (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           cargo run -p package -- --dest-dir dist/ tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 on:
   push:
+    # Ignore non top-level branches.
     branches-ignore:
-    - dependabot/**
+    - '*/**'
   pull_request:
 defaults:
   run:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.11.0
+
+Drop support for `PANTS_SHA` which was deprecated in `0.10.0`.
+
 ## 0.10.8
 
 Redirect pants install messages to a `pants-install.log` file in pants venv directory to not pollute
@@ -50,9 +54,8 @@ It also supports fetching Pants PEXes from behind a firewall.
 ## 0.10.0
 
 This release deprecates support for running against an arbitrary Pants commit using
-`PANTS_SHA=abc123... pants ...`. Pants no longer
-publishes the artifacts required for this for new commits, and so this is becoming less and less
-useful. To replace use of `PANTS_SHA`, do one of:
+`PANTS_SHA=abc123... pants ...`. Pants no longer publishes the artifacts required for this for new
+commits, and so this is becoming less and less useful. To replace use of `PANTS_SHA`, do one of:
 
 - Use a released version of Pants.
 - Run pants from sources (for example: `PANTS_SOURCE=/path/to/pants-checkout pants ...`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.10.8
+
+Redirect pants install messages to a `pants-install.log` file in pants venv directory to not pollute
+stdout/stderr.
+
 ## 0.10.7
 
 This release upgrades `pex` to `v2.1.163` and the bootstrap Python to `3.9.18`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.10.8"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.10.8"
+version = "0.11.0"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.10.7"
+version = "0.10.8"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -56,9 +56,6 @@ name = "pants"
 # appropriate by the default "Boot" one above)
 # description = "Runs a hermetic Pants installation."
 exe = "{scie.bindings.install:PANTS_CLIENT_EXE}"
-args = [
-    "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}",
-]
 
 [lift.commands.env.default]
 PANTS_BUILDROOT_OVERRIDE = "{scie.bindings.configure:PANTS_BUILDROOT_OVERRIDE}"
@@ -90,7 +87,6 @@ __import__("debugpy.server.cli").server.cli.main()
     "127.0.0.1:5678",
     "--wait-for-client",
     "{scie.bindings.install:VIRTUAL_ENV}/bin/pants",
-    "{scie.bindings.configure:PANTS_SHA_FIND_LINKS}",
 ]
 
 [lift.commands.env.default]
@@ -183,8 +179,6 @@ args = [
     "{ptex}",
     "--pants-version",
     "{scie.env.PANTS_VERSION}",
-    "--pants-sha",
-    "{scie.env.PANTS_SHA}",
     "--pants-config",
     "{scie.env.PANTS_TOML}",
     "--github-api-bearer-token",

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -102,31 +102,13 @@ pub(crate) fn run_integration_tests(
         test_tools_pex_reproducibility(workspace_root, tools_pex_path, tools_pex_mismatch_warn);
         test_pants_bootstrap_tools(scie_pants_scie);
 
-        // TODO(John Sirois): The --no-pantsd here works around a fairly prevalent Pants crash on
-        // Linux x86_64 along the lines of the following, but sometimes varying:
-        // >> Verifying PANTS_SHA is respected
-        // Bootstrapping Pants 2.14.0a0+git8e381dbf using cpython 3.9.15
-        // Installing pantsbuild.pants==2.14.0a0+git8e381dbf into a virtual environment at /home/runner/.cache/nce/67f27582b3729c677922eb30c5c6e210aa54badc854450e735ef41cf25ac747f/bindings/venvs/2.14.0a0+git8e381dbf
-        // New virtual environment successfully created at /home/runner/.cache/nce/67f27582b3729c677922eb30c5c6e210aa54badc854450e735ef41cf25ac747f/bindings/venvs/2.14.0a0+git8e381dbf.
-        // 18:11:53.75 [INFO] Initializing scheduler...
-        // 18:11:53.97 [INFO] Scheduler initialized.
-        // 2.14.0a0+git8e381dbf
-        // Fatal Python error: PyGILState_Release: thread state 0x7efe18001140 must be current when releasing
-        // Python runtime state: finalizing (tstate=0x1f4b810)
-        //
-        // Thread 0x00007efe30b75540 (most recent call first):
-        // <no Python frame>
-        // Error: Command "/home/runner/work/scie-pants/scie-pants/dist/scie-pants-linux-x86_64" "--no-verify-config" "-V" failed with exit code: None
-        if matches!(*CURRENT_PLATFORM, Platform::LinuxX86_64) {
-            log!(Color::Yellow, "Turning off pantsd for remaining tests.");
-            env::set_var("PANTS_PANTSD", "False");
-        }
+        log!(Color::Yellow, "Turning off pantsd for remaining tests.");
+        env::set_var("PANTS_PANTSD", "False");
 
-        test_pants_shas(scie_pants_scie);
         test_python_repos_repos(scie_pants_scie);
         test_initialize_new_pants_project(scie_pants_scie);
         test_set_pants_version(scie_pants_scie);
-        test_ignore_empty_pants_version_pants_sha(scie_pants_scie);
+        test_ignore_empty_pants_version(scie_pants_scie);
 
         test_pants_from_pex_version(scie_pants_scie);
         test_pants_from_bad_pex_version(scie_pants_scie);
@@ -341,26 +323,6 @@ fn test_pants_bootstrap_tools(scie_pants_scie: &Path) {
     .unwrap();
 }
 
-fn test_pants_shas(scie_pants_scie: &Path) {
-    for sha in [
-        // initial
-        "8e381dbf90cae57c5da2b223c577b36ca86cace9",
-        // native-client added to wheel
-        "558d843549204bbe49c351d00cdf23402da262c1",
-    ] {
-        integration_test!("Verifying significant PANTS_SHA: {sha}");
-        let existing_project_dir = create_tempdir().unwrap();
-        touch(&existing_project_dir.path().join("pants.toml")).unwrap();
-        execute(
-            Command::new(scie_pants_scie)
-                .current_dir(existing_project_dir.path())
-                .env("PANTS_SHA", sha)
-                .args(["--no-verify-config", "-V"]),
-        )
-        .unwrap();
-    }
-}
-
 fn test_python_repos_repos(scie_pants_scie: &Path) {
     integration_test!(
         "Verifying --python-repos-repos is used prior to Pants 2.13 (no warnings should be \
@@ -403,8 +365,8 @@ fn test_set_pants_version(scie_pants_scie: &Path) {
     .unwrap();
 }
 
-fn test_ignore_empty_pants_version_pants_sha(scie_pants_scie: &Path) {
-    integration_test!("Verifying ignoring PANTS_SHA and PANTS_VERSION when set to empty string");
+fn test_ignore_empty_pants_version(scie_pants_scie: &Path) {
+    integration_test!("Verifying ignoring PANTS_VERSION when set to empty string");
 
     let tmpdir = create_tempdir().unwrap();
 
@@ -421,7 +383,6 @@ fn test_ignore_empty_pants_version_pants_sha(scie_pants_scie: &Path) {
     let output = execute(
         Command::new(scie_pants_scie)
             .arg("-V")
-            .env("PANTS_SHA", "")
             .env("PANTS_VERSION", "")
             .current_dir(&tmpdir)
             .stdout(Stdio::piped()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::ffi::{OsStr, OsString};
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, Context, Result};
 use build_root::BuildRoot;
 use log::{info, trace};
 use logging_timer::{time, timer, Level};
@@ -78,7 +78,7 @@ impl Process {
 fn env_version(env_var_name: &str) -> Result<Option<String>> {
     let raw_version = env::var_os(env_var_name).unwrap_or(OsString::new());
     if raw_version.len() == 0 {
-        // setting PANTS_VERSION= or PANTS_SHA= behaves the same as not setting them
+        // setting PANTS_VERSION= behaves the same as not setting it
         Ok(None)
     } else {
         Ok(Some(raw_version.into_string().map_err(|raw| {
@@ -171,37 +171,11 @@ fn get_pants_process() -> Result<Process> {
             (None, None, None, false)
         };
 
-    let env_pants_sha = env_version("PANTS_SHA")?;
     let env_pants_version = env_version("PANTS_VERSION")?;
-    if let Some(pants_sha) = &env_pants_sha {
-        // when support for PANTS_SHA is fully removed, PANTS_SHA_FIND_LINKS can be removed too
-        eprintln!(
-          "\
-DEPRECATED: Support for PANTS_SHA=... will be removed in a future version of the `pants` launcher.
-
-The artifacts for PANTS_SHA are no longer published for new commits. This invocation set PANTS_SHA={pants_sha}.
-
-To resolve, do one of:
-- Use a released version of Pants.
-- Run pants from sources (for example: `PANTS_SOURCE=/path/to/pants-checkout pants ...`).
-- If these are not appropriate, let us know what you're using it for: <https://www.pantsbuild.org/docs/getting-help>.
-"
-        );
-
-        if let Some(pants_version) = &env_pants_version {
-            bail!(
-                "Both PANTS_SHA={pants_sha} and PANTS_VERSION={pants_version} were set. \
-                Please choose one.",
-            )
-        }
-    }
-
     let pants_version = if let Some(env_version) = env_pants_version {
         Some(env_version)
-    } else if env_pants_sha.is_none() {
-        configured_pants_version.clone()
     } else {
-        None
+        configured_pants_version.clone()
     };
 
     if delegate_bootstrap && pants_version.is_none() {
@@ -264,7 +238,7 @@ To resolve, do one of:
             env.push(("_PANTS_VERSION_OVERRIDE".into(), version.clone().into()));
         }
         env.push(("PANTS_VERSION".into(), version.into()));
-    } else if env_pants_sha.is_none() {
+    } else {
         // Ensure the install binding always re-runs when no Pants version is found so that the
         // the user can be prompted with configuration options.
         env.push((

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -39,7 +39,6 @@ def determine_find_links(
     pants_version: str,
     sha: str,
     find_links_dir: Path,
-    include_nonrelease_pants_distributions_in_findlinks: bool,
 ) -> ResolveInfo:
     abbreviated_sha = sha[:8]
     sha_version = Version(f"{pants_version}+git{abbreviated_sha}")
@@ -62,14 +61,6 @@ def determine_find_links(
                 f"</a>{os.linesep}".encode()
             )
         fp.flush()
-        if include_nonrelease_pants_distributions_in_findlinks:
-            pantsbuild_pants_find_links = (
-                "https://binaries.pantsbuild.org/wheels/pantsbuild.pants/"
-                f"{sha}/{urllib.parse.quote(str(sha_version))}/index.html"
-            )
-            ptex.fetch_to_fp(pantsbuild_pants_find_links, fp)
-        fp.flush()
-
         ptex.fetch_to_fp("https://wheels.pantsbuild.org/simple/", fp)
 
     return ResolveInfo(
@@ -127,7 +118,6 @@ def determine_tag_version(
         pants_version,
         commit_sha,
         find_links_dir,
-        include_nonrelease_pants_distributions_in_findlinks=False,
     )
 
 


### PR DESCRIPTION
The `PANTS_SHA` feature was deprecated with the release `0.10.0` of `scie-pants`.

Broken out of #351 
