### PR TITLE
Bump to pex 2.3.0

### DIFF
--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -20,8 +20,8 @@ version = "3.8.18"
 [[lift.files]]
 name = "pex"
 type = "blob"
-digest = { size = 3677552, fingerprint = "21cb16072357af4b1f4c4e91d2f4d3b00a0f6cc3b0470da65e7176bbac17ec35" }
-source = { url = "https://github.com/pantsbuild/pex/releases/download/v2.1.163/pex", lazy = true }
+digest = { size = 4124506, fingerprint = "581f7c2d61b4c24c66ba241f2a37d8f3b552f24ed22543279860f3463ac3db35" }
+source = { url = "https://github.com/pantsbuild/pex/releases/download/v2.3.0/pex", lazy = true }
 
 [[lift.commands]]
 name = "pex"

--- a/pants.toml
+++ b/pants.toml
@@ -29,12 +29,12 @@ python-default = "tools/lock.json"
 use_rust_parser = true
 
 [pex-cli]
-version = "v2.1.137"
+version = "v2.3.0"
 known_versions = [
-    "v2.1.137|macos_arm64 |faad51a6a108fba9d40b2a10e82a2646fccbaf8c3d9be47818f4bffae02d94b8|4098329",
-    "v2.1.137|macos_x86_64|faad51a6a108fba9d40b2a10e82a2646fccbaf8c3d9be47818f4bffae02d94b8|4098329",
-    "v2.1.137|linux_x86_64|faad51a6a108fba9d40b2a10e82a2646fccbaf8c3d9be47818f4bffae02d94b8|4098329",
-    "v2.1.137|linux_arm64 |faad51a6a108fba9d40b2a10e82a2646fccbaf8c3d9be47818f4bffae02d94b8|4098329",
+    "v2.3.0|macos_arm64 |581f7c2d61b4c24c66ba241f2a37d8f3b552f24ed22543279860f3463ac3db35|4124506",
+    "v2.3.0|macos_x86_64|581f7c2d61b4c24c66ba241f2a37d8f3b552f24ed22543279860f3463ac3db35|4124506",
+    "v2.3.0|linux_x86_64|581f7c2d61b4c24c66ba241f2a37d8f3b552f24ed22543279860f3463ac3db35|4124506",
+    "v2.3.0|linux_arm64 |581f7c2d61b4c24c66ba241f2a37d8f3b552f24ed22543279860f3463ac3db35|4124506",
 ]
 
 [subprocess-environment]


### PR DESCRIPTION
General maintenance bump from 2.1.137 in Pants and 2.1.163 in pbt.toml to 2.3.0 in both places.

This will be required to run with Pants 2.20, which has a minimum supported PEX version of 2.1.148.