### PR TITLE
Fix CI: Use a tmpdir SCIE_BASE to force bootstrapping, incorporate Python path into cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,13 @@ jobs:
         id: build_it_cache_key
         run: |
           # The caches include venvs which have absolute links to Python binaries, so our system
-          # should be resilient to this
+          # should be resilient to this (see `test_pants_source_mode` in `test.rs`).
           echo "cache_key=${{ matrix.os }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
       - name: Cache Build and IT Artifacts
         uses: actions/cache@v3
         with:
           path: ${{ env.SCIE_PANTS_DEV_CACHE }}
-          key: ${{ steps.build_it_cache_key.cache_key }}
+          key: ${{ steps.build_it_cache_key.outputs.cache_key }}
       - name: Build, Package & Integration Tests (MacOS)
         if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64'}}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,17 @@ jobs:
           # N.B.: We need Python 3.9 for running Pants goals against our tools.pex Python tools
           # codebase as well as running Pants from sources in ITs.
           python-version: "3.9"
+      - name: Compute cache key
+        id: build_it_cache_key
+        run: |
+          # The caches include venvs which have absolute links to Python binaries, so our system
+          # should be resilient to this
+          echo "cache_key=${{ matrix.os }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
       - name: Cache Build and IT Artifacts
         uses: actions/cache@v3
         with:
           path: ${{ env.SCIE_PANTS_DEV_CACHE }}
-          key: ${{ matrix.os }}-scie-pants-v6
+          key: ${{ steps.build_it_cache_key.cache_key }}
       - name: Build, Package & Integration Tests (MacOS)
         if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64'}}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Build, Package & Integration Tests (MacOS)
         if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64'}}
         run: |
-          # Clean up the science cache for Pants 2.19.1 setup to ensure it's bootstrapped each run.
-          rm -rf ~/Library/Caches/nce/*/bindings/venv/2.19.1
-
           # TODO(John Sirois): Kill --tools-pex-mismatch-warn:
           #   https://github.com/pantsbuild/scie-pants/issues/2
           #

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -527,6 +527,11 @@ fn test_pants_source_mode(
     pants_2_14_1_venv_dir: &Path,
 ) {
     integration_test!("Verify PANTS_SOURCE mode.");
+    // NB. we assume that these directories are setup perfectly if they exist. A possible failure
+    // mode is the symlinks to python interpreters in the venv; if the system changes to make them
+    // invalid, we start getting errors like `${pants_2_14_1_venv_dir}/.../bin/python: No such file
+    // or directory`. This can occur in practice with cross-runner caching and the runner updating,
+    // but our cache key is designed to avoid this (see `build_it_cache_key` step in ci.yml).
     if !pants_2_14_1_clone_dir.exists() || !pants_2_14_1_venv_dir.exists() {
         let clone_root_tmp = create_tempdir().unwrap();
         let clone_root_path = clone_root_tmp

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -1201,14 +1201,17 @@ fn test_pants_bootstrap_stdout_silent(scie_pants_scie: &Path) {
         "Verifying scie-pants bootstraps Pants without any output on stdout ({issue})",
         issue = issue_link!(20315, "pantsbuild/pants")
     );
+    let tmpdir = create_tempdir().unwrap();
     // Bootstrap a new unseen version of Pants to verify there is no extra output on stdout besides
     // the requested output from the pants command.
     let (output, _stderr) = assert_stderr_output(
         Command::new(scie_pants_scie)
             .arg("-V")
             .env("PANTS_VERSION", "2.19.1")
+            // Customise where SCIE stores its caches to force a bootstrap...
+            .env("SCIE_BASE", tmpdir.path())
             .stdout(Stdio::piped()),
-        // Expect bootstrap messages to ensure we actually bootstrapped pants during this execution.
+        // ...but still assert bootstrap messages to ensure we actually bootstrapped pants during this execution.
         vec![
             "Bootstrapping Pants 2.19.1",
             "Installing pantsbuild.pants==2.19.1 into a virtual environment at ",


### PR DESCRIPTION
There were two issues with CI:

- It seems like the test that verifies silence on stdout wasn't always doing the required bootstrap. This makes the bootstrap always happen by forcing it to be starting with an empty cache (`SCIE_BASE`) by setting that to a fresh temp dir.
- The ubuntu runner was failing to run the `test_pants_source_mode` test, because the venv from the restored cache had an symlink to `/opt/hostedtoolcache/Python/3.9.18/x64/bin/python` (NB version 3.9.18), but the runners have updated to 3.9.19. Fixes #270.