### PR TITLE
Use `ureq` for "science" download, not `cargo install`'d `ptex`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
           # The caches include venvs which have absolute links to Python binaries, so our system
           # should be resilient to this (see `test_pants_source_mode` in `test.rs`).
           echo "cache_key=${{ matrix.os }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
-      - name: Cache Build and IT Artifacts
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.SCIE_PANTS_DEV_CACHE }}
-          key: ${{ steps.build_it_cache_key.outputs.cache_key }}
+      # - name: Cache Build and IT Artifacts
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: ${{ env.SCIE_PANTS_DEV_CACHE }}
+      #     key: ${{ steps.build_it_cache_key.outputs.cache_key }}
 
       # required for the PANTS_SOURCE tests, which build a version of Pants that requires an external protoc
       - name: Install Protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
           # The caches include venvs which have absolute links to Python binaries, so our system
           # should be resilient to this (see `test_pants_source_mode` in `test.rs`).
           echo "cache_key=${{ matrix.os }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
-      # - name: Cache Build and IT Artifacts
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: ${{ env.SCIE_PANTS_DEV_CACHE }}
-      #     key: ${{ steps.build_it_cache_key.outputs.cache_key }}
+      - name: Cache Build and IT Artifacts
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.SCIE_PANTS_DEV_CACHE }}
+          key: ${{ steps.build_it_cache_key.outputs.cache_key }}
 
       # required for the PANTS_SOURCE tests, which build a version of Pants that requires an external protoc
       - name: Install Protoc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +97,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -151,6 +169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -241,6 +268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -402,6 +439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,13 +481,13 @@ dependencies = [
  "fd-lock",
  "lazy_static",
  "log",
- "once_cell",
  "pretty_env_logger",
  "regex",
  "serde_json",
  "sha2",
  "tempfile",
  "termcolor",
+ "ureq",
  "url",
  "walkdir",
 ]
@@ -530,6 +576,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,6 +615,37 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -646,10 +738,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a904882fd5e7723d9113c65cd69c624dddd128f92ac1540c23cd663faba84b"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -791,6 +895,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +964,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -1075,3 +1211,9 @@ checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,6 @@ dependencies = [
  "tempfile",
  "termcolor",
  "ureq",
- "url",
  "walkdir",
 ]
 

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -22,5 +22,4 @@ sha2 = "0.10"
 tempfile = { workspace = true }
 termcolor = "1.4"
 ureq = "2.9"
-url = "2.5"
 walkdir = "2.4"

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -15,12 +15,12 @@ dirs = "5.0"
 fd-lock = "4.0"
 lazy_static = "1.4"
 log = { workspace = true }
-once_cell = "1.19"
 pretty_env_logger = "0.5"
 regex = "1.10"
 serde_json = "1.0.114"
 sha2 = "0.10"
 tempfile = { workspace = true }
 termcolor = "1.4"
+ureq = "2.9"
 url = "2.5"
 walkdir = "2.4"

--- a/package/src/utils/build.rs
+++ b/package/src/utils/build.rs
@@ -3,13 +3,13 @@
 
 use std::cell::Cell;
 use std::env;
+use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
 use log::info;
-use once_cell::sync::OnceCell;
 use sha2::{Digest, Sha256};
 use termcolor::WriteColor;
 use url::Url;
@@ -18,8 +18,6 @@ use crate::utils::exe::{binary_full_name, execute, prepare_exe};
 use crate::utils::fs::{copy, ensure_directory, path_as_str, rename};
 use crate::utils::os::PATHSEP;
 use crate::{build_step, BINARY, SCIENCE_TAG};
-
-const BOOTSTRAP_PTEX_TAG: &str = "v0.7.0";
 
 const CARGO: &str = env!("CARGO");
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
@@ -55,7 +53,13 @@ pub(crate) fn check_sha256(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn fetch_and_check_trusted_sha256(ptex: &Path, url: &str, dest_dir: &Path) -> Result<()> {
+fn fetch_file(url: &str, dest_file: &Path) -> Result<()> {
+    let mut file = File::create(dest_file)?;
+    std::io::copy(&mut ureq::get(url).call()?.into_reader(), &mut file)?;
+    Ok(())
+}
+
+fn fetch_and_check_trusted_sha256(url: &str, dest_dir: &Path) -> Result<()> {
     let parsed_url = Url::parse(url).with_context(|| format!("Failed to parse {url}"))?;
     let url_path = PathBuf::from(parsed_url.path());
     let file_name = url_path
@@ -63,18 +67,13 @@ fn fetch_and_check_trusted_sha256(ptex: &Path, url: &str, dest_dir: &Path) -> Re
         .with_context(|| format!("Failed to determine file name from {url}"))?;
     let dest_file = dest_dir.join(file_name);
 
-    execute(
-        Command::new(ptex)
-            .args(["-O", url.as_ref()])
-            .current_dir(dest_dir),
-    )?;
+    fetch_file(url, &dest_file)?;
 
     let sha256_url = format!("{url}.sha256");
-    execute(
-        Command::new(ptex)
-            .args(["-O", &sha256_url])
-            .current_dir(dest_dir),
-    )?;
+    let mut sha256_dest_file = dest_file.clone();
+    sha256_dest_file.as_mut_os_string().push(".sha256");
+
+    fetch_file(&sha256_url, &sha256_dest_file)?;
 
     info!("Checking downloaded {url} has sha256 reported in {sha256_url}");
     check_sha256(&dest_file)
@@ -141,7 +140,7 @@ impl BuildContext {
                     .current_dir(science_from),
             )?;
         } else {
-            fetch_a_scie_project(self, "lift", SCIENCE_TAG, "science", dest_dir)?;
+            fetch_a_scie_project("lift", SCIENCE_TAG, "science", dest_dir)?;
         }
         let science_exe_path = dest_dir.join(binary_full_name("science"));
         prepare_exe(&science_exe_path)?;
@@ -177,14 +176,11 @@ impl BuildContext {
 }
 
 fn fetch_a_scie_project(
-    build_context: &BuildContext,
     project_name: &str,
     tag: &str,
     binary_name: &str,
     dest_dir: &Path,
 ) -> Result<()> {
-    static BOOTSTRAP_PTEX: OnceCell<PathBuf> = OnceCell::new();
-
     let file_name = binary_full_name(binary_name);
     let cache_dir = crate::utils::fs::dev_cache_dir()?
         .join("downloads")
@@ -204,40 +200,10 @@ fn fetch_a_scie_project(
     let mut lock = fd_lock::RwLock::new(lock_fd);
     let _write_lock = lock.write();
     if !target_dir.exists() {
-        let bootstrap_ptex = BOOTSTRAP_PTEX.get_or_try_init::<_, anyhow::Error>(|| {
-            build_step!("Bootstrapping a `ptex` binary");
-            execute(
-                Command::new(CARGO)
-                    .args([
-                        "install",
-                        "--git",
-                        "https://github.com/a-scie/ptex",
-                        "--tag",
-                        BOOTSTRAP_PTEX_TAG,
-                        "--root",
-                        path_as_str(&build_context.cargo_output_root)?,
-                        "--target",
-                        &build_context.target,
-                        "ptex",
-                    ])
-                    // N.B.: This just suppresses a warning about adding this bin dir to your PATH.
-                    .env(
-                        "PATH",
-                        [
-                            build_context.cargo_output_bin_dir.to_str().unwrap(),
-                            env!("PATH"),
-                        ]
-                        .join(PATHSEP),
-                    ),
-            )?;
-            Ok(build_context.cargo_output_bin_dir.join("ptex"))
-        })?;
-
         build_step!(format!("Fetching the `{project_name}` {tag} binary"));
         let work_dir = cache_dir.join(format!("{tag}.work"));
         ensure_directory(&work_dir, true)?;
         fetch_and_check_trusted_sha256(
-            bootstrap_ptex,
             format!(
                 "https://github.com/a-scie/{project_name}/releases/download/{tag}/{file_name}",
             )


### PR DESCRIPTION
This replaces an inline `cargo install` of https://github.com/a-scie/ptex with the `ureq` library. The `ptex` binary seems to only be used as a "portable" `curl -O <url>`, which can, I think, be done with code built into the `package/` lib itself.

This change:
- conceptually simplifies the "build scie-pants" process
- makes it more reliable/secure (I think the `cargo install` wasn't using `ptex`'s lockfile, because it didn't pass `--locked`)
- potentially speeds up the build when not cached (building ptex has to build a whole lot of libraries, taking 30+s for me).

It also gets rid of two explicit dependencies (`once_cell`, `url`)... but `ureq` depends on both, so they don't actually disappear from the dependency tree. 🤷 

I chose `ureq` because it doesn't seem to add much compilation time. With some benchmarks on my 4-core laptop:

| build type | time before (s) | time after (s) |
|---|---|---|
| clean | 9-10 | 10-11 |
| cached, comment change in `package/src/utils/build.rs` | 0.5-0.6 | 0.5-0.6 |

There's three commits, which can be reviewed individually. The middle one is the interesting one, with the other two minor related refactors.