### PR TITLE
Fix support for Pants 2.25.x / Python 3.11 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.12.1
+
+Support for Pants 2.25.0.dev0 and newer, which run on Python 3.11 instead of 3.9.
+
 ## 0.12.0
 
 Add support for running Pants with newer versions of Python.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -374,6 +374,8 @@ fn test_pants_bootstrap_tools(scie_pants_scie: &Path) {
 
 fn test_pants_2_25_using_python_3_11(scie_pants_scie: &Path) {
     integration_test!("Verifying we can run Pants 2.25+, which uses Python 3.11");
+    // Pants 2.25 is built on macOS 13 (x86-64) and 14 (arm64), and only truly supports those
+    // versions. See https://github.com/pantsbuild/pants/pull/21655
     if is_macos_thats_too_old(13, 14) {
         log!(
             Color::Yellow,

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -115,6 +115,7 @@ pub(crate) fn run_integration_tests(
         log!(Color::Yellow, "Turning off pantsd for remaining tests.");
         env::set_var("PANTS_PANTSD", "False");
 
+        test_pants_2_25_using_python_3_11(scie_pants_scie);
         test_python_repos_repos(scie_pants_scie);
         test_initialize_new_pants_project(scie_pants_scie);
         test_set_pants_version(scie_pants_scie);
@@ -332,6 +333,23 @@ fn test_pants_bootstrap_tools(scie_pants_scie: &Path) {
             .args(["bootstrap-cache-key"]),
     )
     .unwrap();
+}
+
+fn test_pants_2_25_using_python_3_11(scie_pants_scie: &Path) {
+    integration_test!("Verifying we can run Pants 2.25+, which uses Python 3.11");
+    let pants_version = "2.25.0.dev0";
+    let output = execute(
+        Command::new(scie_pants_scie)
+            .env("PANTS_VERSION", pants_version)
+            .arg("-V")
+            .stdout(Stdio::piped()),
+    )
+    .unwrap();
+    let stdout = decode_output(output.stdout).unwrap();
+    assert!(
+        stdout.contains(pants_version),
+        "STDOUT did not contain '{pants_version}':\n{stdout}"
+    );
 }
 
 fn test_python_repos_repos(scie_pants_scie: &Path) {

--- a/package/src/tools_pex.rs
+++ b/package/src/tools_pex.rs
@@ -45,7 +45,7 @@ pub(crate) fn build_tools_pex(
     let requirements = path_as_str(&requirements_path)?;
     let test_requirements_path = tools_path.join("test-requirements.txt");
     let test_requirements = path_as_str(&test_requirements_path)?;
-    let interpreter_constraints = ["--interpreter-constraint", "CPython>=3.8,<3.10"];
+    let interpreter_constraints = ["--interpreter-constraint", "CPython>=3.8,<3.12"];
 
     if update_lock {
         build_step!("Updating the scie_jump tools lock file");

--- a/tools/lock.json
+++ b/tools/lock.json
@@ -241,7 +241,7 @@
     "tomlkit"
   ],
   "requires_python": [
-    "<3.10,>=3.8"
+    "<3.12,>=3.8"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -27,6 +27,7 @@ PANTS_PEX_GITHUB_RELEASE_VERSION = Version("2.0.0.dev0")
 PANTS_PYTHON_VERSIONS = [
     # Sorted on pants version in descending order. Add a new entry when the python version for a
     # particular pants version changes.
+    {"pants": "2.25.0.dev0", "python": "cp311"},
     {"pants": "2.5.0.dev0", "python": "cp39"},
     {"pants": "2.0.0.dev0", "python": "cp38"},
 ]


### PR DESCRIPTION
Fixes #424 

This makes a few adjustments to support running Pants 2.25.0.dev0 and newer, which run using Python 3.11 (https://github.com/pantsbuild/pants/pull/21528), iterating on #351. Particularly:

- expanding tools.pex's interpreter constraints to include 3.11 (and also 3.10, which seems fine)
- add a test (NB. Pants 2.25 cannot run on macOS older than 13 / 14, depending on platform, so this test is conditional: https://github.com/pantsbuild/pants/pull/21655)
- hardcoding that 2.25.0.dev0 uses Python 3.11, to use the optimised "hit the exact URL first time" codepath, instead of having to try all Python versions: https://github.com/pantsbuild/scie-pants/blob/d50bd33fd67e944384c9548811a66c1cb03113a5/tools/src/scie_pants/pants_version.py#L239-L252

This thus preps scie-pants release 0.12.1 too, which I'll tag once merged.