### PR TITLE
Add runs-on config, inheriting from Pants, for Linux arm64 CI

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,2 @@
+# reuse the same runner configuration as the main Pants repo
+_extends: pants


### PR DESCRIPTION
Preparation for #422: this add runs-on configuration to this repo, so we can using it to run GitHub Actions, replacing our CircleCI config (#427).