### PR TITLE
Build a draft release and then publish once complete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,14 +94,37 @@ jobs:
               '
           cargo run -p package -- --dest-dir dist/ scie \
             --scie-pants dist/scie-pants --tools-pex dist/tools.pex
+
+      # Build up a draft release with the artifacts from each of these jobs:
+      - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.determine-tag.outputs.release-tag }}
+          draft: true
+          # placeholder body to help someone track down why a release is still in draft:
+          body: "Release job in progress: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          files: dist/scie-pants-*
+          fail_on_unmatched_files: true
+
+  publish-announce-release:
+    name: Publish and Announce Release
+    needs:
+      - determine-tag
+      - github-release
+    runs-on: ubuntu-22.04
+    steps:
+      # Now, do the human-facing prep on the release (changelog etc.), and publish it
       - name: Prepare Changelog
         id: prepare-changelog
         uses: a-scie/actions/changelog@v1.5
         with:
           changelog-file: ${{ github.workspace }}/CHANGES.md
           version: ${{ needs.determine-tag.outputs.release-version }}
-          setup-python: ${{ matrix.os == 'ubuntu-22.04' }}
-      - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
+          setup-python: true
+
+      - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,16 +134,9 @@ jobs:
           body_path: ${{ steps.prepare-changelog.outputs.changelog-file }}
           draft: false
           prerelease: ${{ needs.determine-tag.outputs.prerelease }}
-          files: dist/scie-pants-*
-          fail_on_unmatched_files: true
           discussion_category_name: Announcements
-  announce-release:
-    name: Announce Release
-    needs:
-      - determine-tag
-      - github-release
-    runs-on: ubuntu-22.04
-    steps:
+
+      # Announce the release! Yay
       - name: Post Release Announcement to Pants Slack `#announce`
         if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
         id: slack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
 
       # Build up a draft release with the artifacts from each of these jobs:
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Instead of publishing partial releases (even for a few minutes) as the matrix of builds adds their artefacts, create a draft release that we then publish in once the build has finished.

Background: the build process involves some set-up, then a matrix of building for different platforms, then some finalisation. This change is moving the "publish the release" from the matrix jobs to the finalisation job.

![image](https://github.com/user-attachments/assets/ec8d2161-6fe3-471c-bdc7-aa1f887f1cf4)


This has a few benefits:

- Atomic publishing: a release is only published once it has artifacts for all platforms. Before this change, if a builder fails for one platform, we'll have published a "latest" release visible to `get-pants.sh`, and so running that on the broken platform will fail. (Example: #430.)
- Reduced duplicate work: rather than have each builder in the matrix compute changelogs etc., just do it once as part of the publishing. This is more conceptually helpful, than an optimisation, since it only takes a few seconds to prep the changelog.