### PR TITLE
Prepare 0.12.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,16 @@
 # Release Notes
 
+## 0.12.2
+
+Support for Pants 2.25.0.dev0 and newer, which run on Python 3.11 instead of 3.9. (This is the first complete release that incorporates this change, that was originally attempted in 0.12.1.)
+
+This release transitions us from using Circle CI to Runs-On-managed runners for Linux AArch64 builds. This change should be invisible to users.
+
 ## 0.12.1
 
 Support for Pants 2.25.0.dev0 and newer, which run on Python 3.11 instead of 3.9.
+
+(NB. this release failed to build on Linux AArch64. See 0.12.2.)
 
 ## 0.12.0
 


### PR DESCRIPTION
This prepares the 0.12.2 release, which only differs to 0.12.1 by including the fix for linux aarch64 builds (#427).

I've validated that change in https://github.com/pantsbuild/scie-pants/releases/tag/v0.12.2-beta.0 (built in https://github.com/pantsbuild/scie-pants/actions/runs/12169046712), which includes the linux aarch64 binaries, and those binaries work in a linux aarch64 docker container locally for me.