### PR TITLE
Fix new draft-release release flow: avoid duplicates, capture changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.determine-tag.outputs.release-tag }}
+          name: scie-pants ${{ needs.determine-tag.outputs.release-version }}
           draft: true
           # placeholder body to help someone track down why a release is still in draft:
           body: "Release job in progress: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       # Now, do the human-facing prep on the release (changelog etc.), and publish it
+      - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.determine-tag.outputs.release-tag }}
+
       - name: Prepare Changelog
         id: prepare-changelog
         uses: a-scie/actions/changelog@v1.5


### PR DESCRIPTION
As observed in https://github.com/pantsbuild/scie-pants/pull/432#issuecomment-2526598191, after #432, release CI has two problems:

- It creates two releases, one as a draft that the artifacts are uploaded too, and then one that's published. I'm guessing this is because the `name` key wasn't set on the draft uploads
- The release notes couldn't be created, because the repo and its code (particularly `CHANGES.md`) wasn't available in the publishing step