### PR TITLE
Build on newer-versions of Github-hosted macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,18 +34,23 @@ jobs:
         include:
           - os: ubuntu-22.04
             name: ubuntu-22.04
+            requires-setup-python: true
 
           - os: [runs-on, runner=4cpu-linux-arm64, image=ubuntu22-full-arm64-python3.7-3.13, "run-id=${{ github.run_id }}"]
             name: linux-arm64
+            requires-setup-python: false
 
           - os: macos-13
             name: "macos-13 x86-64"
+            requires-setup-python: true
 
           - os: macos-14
             name: "macos-14 arm64"
+            requires-setup-python: true
 
           - os: windows-2022
             name: windows-2022
+            requires-setup-python: false
 
     env:
       PY: python3.9
@@ -60,8 +65,8 @@ jobs:
         run: cargo clippy --locked --all
       - name: Unit Tests
         run: cargo test --all
-      - name: Setup Python 3.9 (Ubuntu only)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+      - name: Setup Python 3.9
+        if: ${{ matrix.requires-setup-python }}
         uses: actions/setup-python@v4
         with:
           # N.B.: We need Python 3.9 for running Pants goals against our tools.pex Python tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,24 +106,26 @@ jobs:
           # final PEX content.
           #
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
-            cargo run -p package -- test --check --tools-pex-mismatch-warn
+            cargo run -p package -- --github-api-bearer-token=${{ secrets.GITHUB_TOKEN }} test --check --tools-pex-mismatch-warn
       - name: Build, Package & Integration Tests (Ubuntu)
         if: ${{ matrix.os == 'ubuntu-22.04' || matrix.name == 'linux-arm64' }}
         run: |
-          cargo run -p package -- --dest-dir dist/ tools
+          cargo run -p package -- --github-api-bearer-token=${{ secrets.GITHUB_TOKEN }} --dest-dir dist/ tools
           docker run --rm \
             -v $PWD:/code \
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
             -w /code \
             rust:1.76.0-alpine3.19 \
               sh -c '
                 apk add cmake make musl-dev perl && \
-                cargo run -p package -- --dest-dir dist/ scie-pants
+                cargo run -p package -- --github-api-bearer-token=$GITHUB_TOKEN --dest-dir dist/ scie-pants
               '
           echo
           echo "Running under: $(uname -a)"
           echo
           PANTS_BOOTSTRAP_GITHUB_API_BEARER_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             cargo run -p package -- test \
+              --github-api-bearer-token=${{ secrets.GITHUB_TOKEN }} \
               --tools-pex dist/tools.pex --scie-pants dist/scie-pants \
               --check \
               --tools-pex-mismatch-warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/') }}
 env:
   CARGO_TERM_COLOR: always
+  # We were previously building and publishing on macOS 10.15 (x86-64) and 11 (arm64), so let's
+  # maintain that support
+  MACOSX_DEPLOYMENT_TARGET: 10.15
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -35,11 +38,11 @@ jobs:
           - os: [runs-on, runner=4cpu-linux-arm64, image=ubuntu22-full-arm64-python3.7-3.13, "run-id=${{ github.run_id }}"]
             name: linux-arm64
 
-          - os: macOS-10.15-X64
-            name: macOS-10.15-X64
+          - os: macos-13
+            name: "macos-13 x86-64"
 
-          - os: macOS-11-ARM64
-            name: macOS-11-ARM64
+          - os: macos-14
+            name: "macos-14 arm64"
 
           - os: windows-2022
             name: windows-2022
@@ -85,7 +88,7 @@ jobs:
           version: 23.x
 
       - name: Build, Package & Integration Tests (MacOS)
-        if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64'}}
+        if: ${{ matrix.os == 'macos-13' || matrix.os == 'macos-14'}}
         run: |
           # TODO(John Sirois): Kill --tools-pex-mismatch-warn:
           #   https://github.com/pantsbuild/scie-pants/issues/2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # required for the PANTS_SOURCE tests, which build a version of Pants that requires an external protoc
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        if: ${{ matrix.os == 'macOS-10.15-X64' || matrix.os == 'macOS-11-ARM64' || matrix.os == 'ubuntu-22.04' || matrix.name == 'linux-arm64' }}
+        if: ${{ matrix.os != 'windows-2022' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 23.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           cargo run -p package -- --github-api-bearer-token=${{ secrets.GITHUB_TOKEN }} --dest-dir dist/ tools
           docker run --rm \
             -v $PWD:/code \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -w /code \
             rust:1.76.0-alpine3.19 \
               sh -c '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     needs: org-check
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,9 @@ on:
         required: true
 env:
   CARGO_TERM_COLOR: always
+  # We were previously building and publishing on macOS 10.15 (x86-64) and 11 (arm64), so let's
+  # maintain that support
+  MACOSX_DEPLOYMENT_TARGET: 10.15
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -66,11 +69,11 @@ jobs:
           - os: [runs-on, runner=4cpu-linux-arm64, image=ubuntu22-full-arm64-python3.7-3.13, "run-id=${{ github.run_id }}"]
             name: linux-arm64
 
-          - os: macOS-10.15-X64
-            name: macOS-10.15-X64
+          - os: macos-13
+            name: "macos-13 x86-64"
 
-          - os: macOS-11-ARM64
-            name: macOS-11-ARM64
+          - os: macos-14
+            name: "macos-14 arm64"
     environment: Release
     steps:
       - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -144,6 +144,8 @@ struct Args {
         default_value_t = SpecifiedPath::new("dist")
     )]
     dest_dir: SpecifiedPath,
+    #[arg(long, help = "The GITHUB_TOKEN to use if running in CI context.")]
+    github_api_bearer_token: Option<String>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -239,7 +241,11 @@ fn main() -> Result<()> {
         );
     }
 
-    let build_context = BuildContext::new(args.target.as_deref(), args.science.as_deref())?;
+    let build_context = BuildContext::new(
+        args.target.as_deref(),
+        args.science.as_deref(),
+        args.github_api_bearer_token.as_deref(),
+    )?;
     if let Some(scie_pants) = maybe_build(&args, &build_context)? {
         ensure_directory(dest_dir, false)?;
 

--- a/package/src/tools_pex.rs
+++ b/package/src/tools_pex.rs
@@ -32,10 +32,13 @@ pub(crate) fn build_tools_pex(
     hardlink(&pbt_manifest, &pbt_manifest_dst)?;
 
     execute(
-        science
-            .command()
-            .args(["lift", "build"])
-            .current_dir(&pbt_package_dir),
+        build_context.apply_github_api_bearer_token_if_available(
+            science
+                .command()
+                .args(["lift", "build"])
+                .current_dir(&pbt_package_dir),
+            "SCIENCE_AUTH_GITHUB_COM_BEARER",
+        ),
     )?;
 
     let tools_path = build_context.workspace_root.join("tools");

--- a/package/src/utils/build.rs
+++ b/package/src/utils/build.rs
@@ -81,10 +81,15 @@ pub(crate) struct BuildContext {
     target_prepared: Cell<bool>,
     science_repo: Option<PathBuf>,
     cargo_output_bin_dir: PathBuf,
+    github_api_bearer_token: Option<String>,
 }
 
 impl BuildContext {
-    pub(crate) fn new(target: Option<&str>, science_repo: Option<&Path>) -> Result<Self> {
+    pub(crate) fn new(
+        target: Option<&str>,
+        science_repo: Option<&Path>,
+        github_api_bearer_token: Option<&str>,
+    ) -> Result<Self> {
         let target = target.unwrap_or(TARGET).to_string();
         let package_crate_root = PathBuf::from(CARGO_MANIFEST_DIR);
         let workspace_root = package_crate_root
@@ -102,6 +107,7 @@ impl BuildContext {
             target_prepared: Cell::new(false),
             science_repo: science_repo.map(Path::to_path_buf),
             cargo_output_bin_dir: output_bin_dir,
+            github_api_bearer_token: github_api_bearer_token.map(String::from),
         })
     }
 
@@ -166,6 +172,17 @@ impl BuildContext {
             .cargo_output_bin_dir
             .join(BINARY)
             .with_extension(env::consts::EXE_EXTENSION))
+    }
+
+    pub(crate) fn apply_github_api_bearer_token_if_available<'c>(
+        &self,
+        cmd: &'c mut Command,
+        env_var_name: &str,
+    ) -> &'c mut Command {
+        if let Some(token) = self.github_api_bearer_token.as_ref() {
+            cmd.env(env_var_name, token);
+        }
+        cmd
     }
 }
 

--- a/tools/src/scie_pants/configure_pants.py
+++ b/tools/src/scie_pants/configure_pants.py
@@ -78,6 +78,8 @@ def main() -> NoReturn:
     if not env_file:
         fatal("Expected SCIE_BINDING_ENV to be set in the environment")
 
+    info(f"has bearer token? {options.github_api_bearer_token is not None}")
+
     ptex = get_ptex(options)
 
     find_links_dir = base_dir / "find_links"


### PR DESCRIPTION
This switches us to building macOS binaries on Github-hosted runners:

- macOS 13 for x86-64
- macOS 14 for arm64

This then follows https://rust-cli.github.io/book/tutorial/packaging.html#building-binary-releases-on-ci to set `MACOSX_DEPLOYMENT_TARGET` to preserve our platform support.

Fixes #421 