### PR TITLE
Add workaround for action mishandling of draft: true -> false transition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,10 @@ jobs:
 
       # Build up a draft release with the artifacts from each of these jobs:
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
-        uses: softprops/action-gh-release@v2
+        # Need to pull in https://github.com/softprops/action-gh-release/pull/316 to work-around
+        # double-release-creation that happens when attempting to update a draft release to
+        # not-draft.
+        uses: huonw/action-gh-release@55ec297e11bf84ff0f5893a84ea987d93489920c # v2.2.0 + https://github.com/softprops/action-gh-release/pull/316
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -131,7 +134,8 @@ jobs:
           setup-python: true
 
       - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
-        uses: softprops/action-gh-release@v2
+        # See above for discussion:
+        uses: huonw/action-gh-release@55ec297e11bf84ff0f5893a84ea987d93489920c # v2.2.0 + https://github.com/softprops/action-gh-release/pull/316
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This works around `softprops/action-gh-release` not being able to properly "publish" a release by changing `draft: true` to `draft: false`.

The intention is that the step with `draft: false` would find the existing draft release and update it, but, previously, the action would fail to find the existing draft release and instead create a duplicate one. The old behaviour is visible (to people who can see draft releases) with v0.12.3-beta.0 and -beta.1:

![image](https://github.com/user-attachments/assets/106d43b3-d2f8-4d2d-aaf3-123a9d87e096)


The particular new version of the action is:

- changes: https://github.com/softprops/action-gh-release/compare/master...huonw:action-gh-release:huonw/pantsbuild-fix-see-scie-pants-439 (specifically commit https://github.com/huonw/action-gh-release/commit/55ec297e11bf84ff0f5893a84ea987d93489920c from branch https://github.com/huonw/action-gh-release/commits/huonw/pantsbuild-fix-see-scie-pants-439 )
- this is just the latest code (v2.2.0) with https://github.com/softprops/action-gh-release/pull/316 merged in

