### PR TITLE
Add workaround for release publishing action mishandling `draft: true` -> `false` transition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,10 @@ jobs:
 
       # Build up a draft release with the artifacts from each of these jobs:
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
-        uses: softprops/action-gh-release@v2
+        # Need to pull in https://github.com/softprops/action-gh-release/pull/316 to work-around
+        # double-release-creation that happens when attempting to update a draft release to
+        # not-draft.
+        uses: huonw/action-gh-release@55ec297e11bf84ff0f5893a84ea987d93489920c # v2.2.0 + https://github.com/softprops/action-gh-release/pull/316
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -131,7 +134,8 @@ jobs:
           setup-python: true
 
       - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
-        uses: softprops/action-gh-release@v2
+        # See above for discussion:
+        uses: huonw/action-gh-release@55ec297e11bf84ff0f5893a84ea987d93489920c # v2.2.0 + https://github.com/softprops/action-gh-release/pull/316
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
         # Need to pull in https://github.com/softprops/action-gh-release/pull/316 to work-around
         # double-release-creation that happens when attempting to update a draft release to
         # not-draft.
-        uses: huonw/action-gh-release@55ec297e11bf84ff0f5893a84ea987d93489920c # v2.2.0 + https://github.com/softprops/action-gh-release/pull/316
+        uses: huonw/action-gh-release@998f80d5380609557d7464b01d59a10d845600a0 # v2.0.9 (v2) + https://github.com/softprops/action-gh-release/pull/316
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -135,7 +135,7 @@ jobs:
 
       - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
         # See above for discussion:
-        uses: huonw/action-gh-release@55ec297e11bf84ff0f5893a84ea987d93489920c # v2.2.0 + https://github.com/softprops/action-gh-release/pull/316
+        uses: huonw/action-gh-release@998f80d5380609557d7464b01d59a10d845600a0 # v2.0.9 (v2) + https://github.com/softprops/action-gh-release/pull/316
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
This works around `softprops/action-gh-release` not being able to properly "publish" a release by changing `draft: true` to `draft: false`.

The intention is that the step with `draft: false` would find the existing draft release and update it (publishing it). This is what correctly happened for a testing `v0.12.3-beta.3` release from this branch: https://github.com/pantsbuild/scie-pants/releases/tag/v0.12.3-beta.3 (I also did attempted a `v0.12.3-beta.2` from this branch, but that used a newer version of the action code and failed completely, see below.)

Previously, the action would fail to find the existing draft release and instead create a duplicate one. The old behaviour is visible (to people who can see draft releases) with `v0.12.3-beta.0` and `-beta.1`:

![image](https://github.com/user-attachments/assets/106d43b3-d2f8-4d2d-aaf3-123a9d87e096)


The particular new version of the action is:

- changes: https://github.com/softprops/action-gh-release/compare/master...huonw:action-gh-release:huonw/pantsbuild-fix-see-scie-pants-439 (specifically commit https://github.com/huonw/action-gh-release/commit/998f80d5380609557d7464b01d59a10d845600a0 from branch https://github.com/huonw/action-gh-release/commits/huonw/pantsbuild-fix-see-scie-pants-439 )
- this is v2.0.9 (the current `v2` tag) with https://github.com/softprops/action-gh-release/pull/316 merged in
- using v2.2.0 (the latest version of the action) fails while uploading artifacts with errors like `Request body length does not match content-length header`, so this sticks with the older version.
