### PR TITLE
Add Python 3.12 and Python 3.13 as probe-able versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.12.3
+
+Add support for running potential future Pants versions that use Python 3.12 or Python 3.13. No versions of Pants use those versions of Python yet.
+
 ## 0.12.2
 
 Support for Pants 2.25.0.dev0 and newer, which run on Python 3.11 instead of 3.9. (This is the first complete release that incorporates this change, that was originally attempted in 0.12.1.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -42,6 +42,20 @@ release = "20240415"
 lazy = true
 version = "3.11.9"
 
+[[lift.interpreters]]
+id = "cpython312"
+provider = "PythonBuildStandalone"
+release = "20250106"
+lazy = true
+version = "3.12.8"
+
+[[lift.interpreters]]
+id = "cpython313"
+provider = "PythonBuildStandalone"
+release = "20250106"
+lazy = true
+version = "3.13.1"
+
 [[lift.interpreter_groups]]
 id = "cpython"
 selector = "{scie.bindings.configure:PYTHON}"
@@ -50,6 +64,8 @@ members = [
     "cpython39",
     "cpython310",
     "cpython311",
+    "cpython312",
+    "cpython313",
 ]
 
 [[lift.files]]

--- a/tools/src/scie_pants/pants_version.py
+++ b/tools/src/scie_pants/pants_version.py
@@ -34,6 +34,8 @@ PANTS_PYTHON_VERSIONS = [
 PYTHON_IDS = {
     # N.B.: These values must match the lift TOML interpreter ids.
     # Important: all pythons used in pants_python_versions.json must be represented in this list.
+    "cp313": "cpython313",
+    "cp312": "cpython312",
     "cp311": "cpython311",
     "cp310": "cpython310",
     "cp39": "cpython39",


### PR DESCRIPTION
This (theoretically) adds support for running future Pants PEXes that requires Python 3.12 or 3.13 by adding them as versions that the fallback "probing" loop will query.

This will hopefully reduce how often we need to force users to upgrade their scie-pants runner, because current versions of scie-pants will support more Python versions, giving us a bit more flexibility with doing internal upgrades.

(Worst case: there's a problem in this PR and it doesn't work for the actual future 3.12/3.13-using versions of Pants... but, that's seemingly no worse than we were before, without any support at all.)

## Background

Scie-pants downloads and runs PEXes from Pants releases. These PEXes require a specific Python version, that's indicated in the URL, e.g. <https://github.com/pantsbuild/pants/releases/download/release_2.25.0.dev4/pants.2.25.0.dev4-cp311-darwin_arm64.pex> (NB. `cp311`). There's two aspects of scie-pants working with these:

- hard-coding the different Python versions, to have lift/ptex be able to download the right interpreter (in `scie-pants.toml`)
- logic to find the right artifact to download: https://github.com/pantsbuild/scie-pants/blob/9d73b15a0f602de1359c842a7b153b1dda53c7e9/tools/src/scie_pants/pants_version.py#L239-L253
  - first guess the URL based on the requested version, with hard-coded known cut-overs: https://github.com/pantsbuild/scie-pants/blob/9d73b15a0f602de1359c842a7b153b1dda53c7e9/tools/src/scie_pants/pants_version.py#L27-L33
  - if that fails, then fallback to guessing successive URLs based on the known-versions (i.e. several requests to probe the possible request artifacts)

The fallback feature allows us to have current scie-pants support potential future versions of Pants, to reduce how often users are forced to upgrade their scie-pants runner installation.


## Example

Imagine we release 2.34.0 with cp312 support and had made no other changes, this gives an artifact like `pants.2.34.0-cp312-darwin_arm64.pex`:
1. Scie-pants' initial guess tries to download `pants.2.34.0-cp311-darwin_arm64.pex` (because 2.34.0 >= 2.25.0.dev0, which is the hard-coded cp311 threshold in `PANTS_PYTHON_VERSIONS`), but this would fail.
2. The fallback kicks in to go through the various `PYTHON_IDS`. It eventually hits `pants.2.34.0-cp312-darwin_arm64.pex` and succeeds, getting Pants 2.34 running for that user!

Without this PR, step 2 would only run through 3.8 - 3.11, not find the artifact, and thus the overall installation would fail.

(Hard-coding the version threshold once we know it will make this bootstrapping (slightly) more efficient/send fewer requests, but the fallback + extra versions means scie-pants is at least functional.)