### PR TITLE
Upgrade to science 0.11.2

### DIFF
--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -30,7 +30,7 @@ use crate::utils::fs::{base_name, canonicalize, copy, ensure_directory};
 const BINARY: &str = "scie-pants";
 
 // The version of a-scie/lift to use by default.
-const SCIENCE_TAG: &str = "v0.3.1";
+const SCIENCE_TAG: &str = "v0.11.2";
 
 #[derive(Clone)]
 struct SpecifiedPath(PathBuf);


### PR DESCRIPTION
This bumps to the latest version of https://github.com/a-scie/lift, since we haven't done it for a while.

This also specifically picks up the download retries in https://github.com/a-scie/lift/releases/tag/v0.10.1 which may make things slightly more reliable. (I occasionally see errors like `KeyError: "name"` from science's attempts to download PBS.)