### PR TITLE
Update this repo's orchestrating Pants 2.21 -> 2.23

### DIFF
--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -1301,14 +1301,28 @@ fn test_pants_bootstrap_stdout_silent(scie_pants_scie: &Path) {
         issue = issue_link!(20315, "pantsbuild/pants")
     );
     let tmpdir = create_tempdir().unwrap();
+
+    let scie_base_dir = tmpdir.path().join("scie-base");
+
+    let pants_release = "2.19.1";
+    let pants_toml_content = format!(
+        r#"
+        [GLOBAL]
+        pants_version = "{pants_release}"
+        "#
+    );
+    let run_dir = tmpdir.path().join("run");
+    let pants_toml = run_dir.join("pants.toml");
+    write_file(&pants_toml, false, pants_toml_content).unwrap();
+
     // Bootstrap a new unseen version of Pants to verify there is no extra output on stdout besides
     // the requested output from the pants command.
     let (output, _stderr) = assert_stderr_output(
         Command::new(scie_pants_scie)
             .arg("-V")
-            .env("PANTS_VERSION", "2.19.1")
+            .current_dir(&run_dir)
             // Customise where SCIE stores its caches to force a bootstrap...
-            .env("SCIE_BASE", tmpdir.path())
+            .env("SCIE_BASE", scie_base_dir)
             .stdout(Stdio::piped()),
         // ...but still assert bootstrap messages to ensure we actually bootstrapped pants during this execution.
         vec![

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -320,7 +320,13 @@ fn test_pants_bootstrap_handling(scie_pants_scie: &Path) {
     // a need to restart.
     let output = execute(
         Command::new(scie_pants_scie)
-            .args(["--no-pantsd", "-V"])
+            .args([
+                "--no-pantsd",
+                "-V",
+                // Work around https://github.com/pantsbuild/pants/issues/21863, which results in
+                // irrelevant nailgun-related log lines
+                "--no-process-execution-local-enable-nailgun",
+            ])
             .stderr(Stdio::piped()),
     )
     .unwrap();

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -326,8 +326,9 @@ fn test_pants_bootstrap_handling(scie_pants_scie: &Path) {
     .unwrap();
     assert!(
         output.stderr.is_empty(),
-        "Expected no warnings to be printed when handling .pants.bootstrap, found:\n{warnings}",
-        warnings = String::from_utf8_lossy(&output.stderr)
+        "Expected no warnings to be printed when handling .pants.bootstrap, found:\n{warnings}\n\n{raw:?}",
+        warnings = String::from_utf8_lossy(&output.stderr),
+        raw = output.stderr,
     );
 }
 

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -322,10 +322,10 @@ fn test_pants_bootstrap_handling(scie_pants_scie: &Path) {
         Command::new(scie_pants_scie)
             .args([
                 "--no-pantsd",
-                "-V",
                 // Work around https://github.com/pantsbuild/pants/issues/21863, which results in
                 // irrelevant nailgun-related log lines
                 "--no-process-execution-local-enable-nailgun",
+                "-V",
             ])
             .stderr(Stdio::piped()),
     )

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -326,9 +326,8 @@ fn test_pants_bootstrap_handling(scie_pants_scie: &Path) {
     .unwrap();
     assert!(
         output.stderr.is_empty(),
-        "Expected no warnings to be printed when handling .pants.bootstrap, found:\n{warnings}\n\n{raw:?}",
-        warnings = String::from_utf8_lossy(&output.stderr),
-        raw = output.stderr,
+        "Expected no warnings to be printed when handling .pants.bootstrap, found:\n{warnings}",
+        warnings = String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.21.0"
+pants_version = "2.23.0"
 
 backend_packages = [
     "pants.backend.python",

--- a/pants.toml
+++ b/pants.toml
@@ -8,6 +8,9 @@ backend_packages = [
     "pants.backend.python.typecheck.mypy",
 ]
 
+# FIXME #421: remove this once scie-pants's CI doesn't use these versions
+allow_deprecated_macos_before_12 = true
+
 [anonymous-telemetry]
 enabled = true
 repo_id = "e0b99427-9bc2-4f6a-b197-f5f378849b15"


### PR DESCRIPTION
This just updates the Pants version used for linting etc., should be no functional change.

This requires a few extra changes:

- CI here runs on older versions of macOS that we're removing support for (#421) and thus needs to silence the warnings with `allow_deprecated_macos_before_12`
  - doing so causes issues with a few tests that ran against this repo's `pants.toml` with older versions of Pants that don't understand that option, and thus those tests are adjusted to use a dedicated `pants.toml`
- working around https://github.com/pantsbuild/pants/issues/21863