### PR TITLE
upgrade to Rust v1.86.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           docker run --rm \
             -v $PWD:/code \
             -w /code \
-            rust:1.76.0-alpine3.19 \
+            rust:1.86.0-alpine3.20 \
               sh -c '
                 apk add cmake make musl-dev perl && \
                 cargo run -p package -- --dest-dir dist/ scie-pants

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,6 +1,6 @@
 [toolchain]
-# N.B.: Update .github and .circleci yaml to use a matching image.
-channel = "1.76.0"
+# N.B.: Update .github to use a matching image.
+channel = "1.86.0"
 components = [
   "cargo",
   "clippy",

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ impl Process {
 
 fn env_version(env_var_name: &str) -> Result<Option<String>> {
     let raw_version = env::var_os(env_var_name).unwrap_or_default();
-    if raw_version.len() == 0 {
+    if raw_version.is_empty() {
         // setting PANTS_VERSION= behaves the same as not setting it
         Ok(None)
     } else {

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -113,7 +113,7 @@ def install_pants_from_pex(
         except subprocess.CalledProcessError as e:
             fatal(
                 f"Failed to create Pants virtual environment.\nError: {e}, output:"
-                f"\n-----\n{e.stdout}\n-----\n"
+                f"\n-----\n{e.stdout.decode(errors='replace')}\n-----\n"
             )
         else:
             with open(str(venv_dir / "pants-install.log"), "a") as fp:


### PR DESCRIPTION
Upgrade Rust to v1.86.0. (As a side effect, this allows rust-analyzer in VScode to be able to work with scie-pants repository again.)

The `rust` Docker image in CI is bumped to Alpine 3.20 since an Alpine 3.19 variant is not available.