### PR TITLE
add a better error message for an invalid Pants source directory

### DIFF
--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -756,6 +756,21 @@ index 796b3cddd2..aef0e649bb 100644
         ],
         ExpectedResult::Success,
     );
+
+    let invalid_pants_clone_dir = pants_2_25_0_dev1_clone_dir.join("xyzzy");
+    assert_stderr_output(
+        Command::new(scie_pants_scie)
+            .arg("-V")
+            .env("PANTS_SOURCE", &invalid_pants_clone_dir)
+            .env("SCIE_PANTS_TEST_MODE", "PANTS_SOURCE mode")
+            .env("PANTS_VENV_DIR_PREFIX", pants_2_25_0_dev1_venv_dir),
+        vec![
+            &format!("Error: Unable to find the `pants` runner script in the requested Pants source directory `{}`. \
+            Running Pants from sources was enabled because the `PANTS_SOURCE` environment variable is set.",
+            invalid_pants_clone_dir.display())
+        ],
+        ExpectedResult::Failure,
+    );
 }
 
 fn test_pants_from_sources_mode(
@@ -776,16 +791,32 @@ fn test_pants_from_sources_mode(
     softlink(scie_pants_scie, &pants_from_sources).unwrap();
 
     assert_stderr_output(
-        Command::new(pants_from_sources)
+        Command::new(&pants_from_sources)
             .arg("-V")
             .env("SCIE_PANTS_TEST_MODE", "pants_from_sources mode")
             .env("PANTS_VENV_DIR_PREFIX", pants_2_25_0_dev1_venv_dir)
-            .current_dir(user_repo_dir),
+            .current_dir(&user_repo_dir),
         vec![
             "The pants_from_sources mode is working.",
             "Pants from sources argv: --no-verify-config -V.",
         ],
         ExpectedResult::Success,
+    );
+
+    let invalid_pants_dir = side_by_side_root.path().join("pants-xyzzy");
+    rename(&pants_dir, &invalid_pants_dir).unwrap();
+    assert_stderr_output(
+        Command::new(&pants_from_sources)
+            .arg("-V")
+            .env("SCIE_PANTS_TEST_MODE", "pants_from_sources mode")
+            .env("PANTS_VENV_DIR_PREFIX", pants_2_25_0_dev1_venv_dir)
+            .current_dir(&user_repo_dir),
+        vec![
+            &format!("Error: Unable to find the `pants` runner script in the requested Pants source directory `{}`. \
+            Running Pants from sources was enabled because the Pants launcher was invoked as `pants_from_sources`",
+            invalid_pants_dir.display())
+        ],
+        ExpectedResult::Failure,
     );
 }
 

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -813,7 +813,7 @@ fn test_pants_from_sources_mode(
             .current_dir(&user_repo_dir),
         vec![
             &format!("Error: Unable to find the `pants` runner script in the requested Pants source directory `{}`. \
-            Running Pants from sources was enabled because the Pants launcher was invoked as `pants_from_sources`",
+            Running Pants from sources was enabled because the Pants launcher was invoked as `pants_from_sources`.",
             invalid_pants_dir.display())
         ],
         ExpectedResult::Failure,

--- a/package/src/test.rs
+++ b/package/src/test.rs
@@ -812,9 +812,8 @@ fn test_pants_from_sources_mode(
             .env("PANTS_VENV_DIR_PREFIX", pants_2_25_0_dev1_venv_dir)
             .current_dir(&user_repo_dir),
         vec![
-            &format!("Error: Unable to find the `pants` runner script in the requested Pants source directory `{}`. \
-            Running Pants from sources was enabled because the Pants launcher was invoked as `pants_from_sources`.",
-            invalid_pants_dir.display())
+            &format!("Error: Unable to find the `pants` runner script in the requested Pants source directory `../pants`. \
+            Running Pants from sources was enabled because the Pants launcher was invoked as `pants_from_sources`.")
         ],
         ExpectedResult::Failure,
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,7 @@ fn get_pants_from_sources_process(
     let exe = pants_repo_location.join("pants");
     if !exe.exists() {
         return Err(anyhow!(
-            "Unable to find the `pants` runner script in the Pants source directory `{}`. \
+            "Unable to find the `pants` runner script in the requested Pants source directory `{}`. \
             Running Pants from sources was enabled because {origin_of_pants_repo_location}.",
             pants_repo_location.display()
         ));
@@ -331,7 +331,7 @@ fn main() -> Result<()> {
     } else if let Some("pants_from_sources") = invoked_as_basename().as_deref() {
         get_pants_from_sources_process(
             PathBuf::from("..").join("pants"),
-            "Pants was invoked as `pants_from_sources`",
+            "the Pants launcher was invoked as `pants_from_sources`",
         )
     } else {
         get_pants_process()

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,8 +250,19 @@ fn get_pants_process() -> Result<Process> {
     scie_boot.into_process(scie, build_root, env)
 }
 
-fn get_pants_from_sources_process(pants_repo_location: PathBuf) -> Result<Process> {
-    let exe = pants_repo_location.join("pants").into_os_string();
+fn get_pants_from_sources_process(
+    pants_repo_location: PathBuf,
+    origin_of_pants_repo_location: &str,
+) -> Result<Process> {
+    let exe = pants_repo_location.join("pants");
+    if !exe.exists() {
+        return Err(anyhow!(
+            "Unable to find the `pants` runner script in the Pants source directory `{}`. \
+            Running Pants from sources was enabled because {origin_of_pants_repo_location}.",
+            pants_repo_location.display()
+        ));
+    }
+    let exe = exe.into_os_string();
 
     let args = vec!["--no-verify-config".into()];
 
@@ -313,9 +324,15 @@ fn main() -> Result<()> {
     }
 
     let pants_process = if let Ok(value) = env::var("PANTS_SOURCE") {
-        get_pants_from_sources_process(PathBuf::from(value))
+        get_pants_from_sources_process(
+            PathBuf::from(value),
+            "the `PANTS_SOURCE` environment variable is set",
+        )
     } else if let Some("pants_from_sources") = invoked_as_basename().as_deref() {
-        get_pants_from_sources_process(PathBuf::from("..").join("pants"))
+        get_pants_from_sources_process(
+            PathBuf::from("..").join("pants"),
+            "Pants was invoked as `pants_from_sources`",
+        )
     } else {
         get_pants_process()
     }?;


### PR DESCRIPTION
Currently, if the `PANTS_SOURCE` directory does not exist, then the error message is a very obtuse `Error: No such file or directory (os error 2)` without any other explanation.  Detect the case when the source directory does not exist and emit an error message with an actual explanation.