### PR TITLE
upgrade SCIE dependencies to latest versions

### DIFF
--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -4,11 +4,15 @@ description = """\
 Python Build Tool: A BusyBox that provides `python`, `pip`, `pex`, `pex3` and `pex-tools`.\
 """
 
+# Downloader tool
+# https://github.com/a-scie/ptex
 [lift.ptex]
-version = "0.7.0"
+version = "1.6.1"
 
+# SCIE launcher
+# https://github.com/a-scie/jump
 [lift.scie_jump]
-version = "0.14.0"
+version = "1.7.0"
 
 [[lift.interpreters]]
 id = "cpython"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -6,13 +6,17 @@ load_dotenv = true
 [lift.app_info]
 repo = "https://github.com/pantsbuild/scie-pants"
 
+# Downloader tool
+# https://github.com/a-scie/ptex
 [lift.ptex]
 id = "ptex"
-version = "0.7.0"
+version = "1.6.1"
 argv1 = "{scie.env.PANTS_BOOTSTRAP_URLS={scie.lift}}"
 
+# SCIE launcher
+# https://github.com/a-scie/jump
 [lift.scie_jump]
-version = "0.14.0"
+version = "1.7.0"
 
 [[lift.interpreters]]
 id = "cpython38"

--- a/package/src/main.rs
+++ b/package/src/main.rs
@@ -29,8 +29,8 @@ use crate::utils::fs::{base_name, canonicalize, copy, ensure_directory};
 
 const BINARY: &str = "scie-pants";
 
-// The version of a-scie/lift to use by default.
-const SCIENCE_TAG: &str = "v0.11.2";
+/// The version of [lift](https://github.com/a-scie/lift) to use by default.
+const SCIENCE_TAG: &str = "v0.12.2";
 
 #[derive(Clone)]
 struct SpecifiedPath(PathBuf);


### PR DESCRIPTION
Upgrade the SCIE and related dependencies to the latest versions:

- Science v0.12.2
- scie-jump v1.7.0
- ptex v1.6.1
