### PR TITLE
upgrade PBS Pythons to `20250612` release

### DIFF
--- a/package/pbt.toml
+++ b/package/pbt.toml
@@ -13,9 +13,9 @@ version = "0.14.0"
 [[lift.interpreters]]
 id = "cpython"
 provider = "PythonBuildStandalone"
-release = "20240107"
+release = "20241002"
 lazy = true
-version = "3.8.18"
+version = "3.8.20"
 
 [[lift.files]]
 name = "pex"

--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -17,44 +17,44 @@ version = "0.14.0"
 [[lift.interpreters]]
 id = "cpython38"
 provider = "PythonBuildStandalone"
-release = "20240909"
+release = "20241002"
 lazy = true
 version = "3.8.20"
 
 [[lift.interpreters]]
 id = "cpython39"
 provider = "PythonBuildStandalone"
-release = "20250409"
+release = "20250612"
 lazy = true
-version = "3.9.22"
+version = "3.9.23"
 
 [[lift.interpreters]]
 id = "cpython310"
 provider = "PythonBuildStandalone"
-release = "20250409"
+release = "20250612"
 lazy = true
-version = "3.10.17"
+version = "3.10.18"
 
 [[lift.interpreters]]
 id = "cpython311"
 provider = "PythonBuildStandalone"
-release = "20250409"
+release = "20250612"
 lazy = true
-version = "3.11.12"
+version = "3.11.13"
 
 [[lift.interpreters]]
 id = "cpython312"
 provider = "PythonBuildStandalone"
-release = "20250409"
+release = "20250612"
 lazy = true
-version = "3.12.10"
+version = "3.12.11"
 
 [[lift.interpreters]]
 id = "cpython313"
 provider = "PythonBuildStandalone"
-release = "20250409"
+release = "20250612"
 lazy = true
-version = "3.13.3"
+version = "3.13.5"
 
 [[lift.interpreter_groups]]
 id = "cpython"


### PR DESCRIPTION
Upgrade the versions of Python Build Standalone interpreters to `20250612` releases.