### PR TITLE
Prepare the 0.12.4 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 0.12.4
+
+A better error message for an invalid Pants source directory.
+
+Update to latest patch versions of Python interpreters.
+
 ## 0.12.3
 
 Add support for running potential future Pants versions that use Python 3.12 or Python 3.13. No versions of Pants use those versions of Python yet.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "scie-pants"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 [package]
 name = "scie-pants"
 description = "Protects your Pants from the elements."
-version = "0.12.3"
+version = "0.12.4"
 edition = "2021"
 authors = [
     "John Sirois <john.sirois@gmail.com>",


### PR DESCRIPTION
This release differs only slightly from 0.12.3
(it includes upgrades of Python versions, and an
improved error message).

We are releasing it primarily to check that the release
process works with a recent CI infrastructure change.