### PR TITLE
preserve environ (esp HOME) when calling scie in subprocess

### DIFF
--- a/tools/src/scie_pants/record_scie_pants_info.py
+++ b/tools/src/scie_pants/record_scie_pants_info.py
@@ -36,7 +36,7 @@ def main() -> NoReturn:
 
     version = subprocess.run(
         args=[options.scie],
-        env={"PANTS_BOOTSTRAP_VERSION": "report"},
+        env={**os.environ, "PANTS_BOOTSTRAP_VERSION": "report"},
         stdout=subprocess.PIPE,
         text=True,
         check=True,


### PR DESCRIPTION
Fixes #263

#13 introduced both of these `PANTS_BOOTSTRAP_VERSION=report pants` subprocess calls with one crucial difference: one of them does not preserve `os.environ`. Without that, scie failes to find its nce cache, and everything falls over.

This one preserves `os.environ`:
https://github.com/pantsbuild/scie-pants/blob/e61e619599983ac4f6efd4fe627ec70f725d58ea/tools/src/scie_pants/update_scie_pants.py#L184-L186

This one does not preserve `os.environ` causing the failure documented in #263.
https://github.com/pantsbuild/scie-pants/blob/e61e619599983ac4f6efd4fe627ec70f725d58ea/tools/src/scie_pants/record_scie_pants_info.py#L37-L39

Why does this happen? When a host depends on NSS for the `passwd` database (eg for remote AD or LDAP accounts made available to the system through SSSD), scies cannot resolve `~` without the `HOME` env var. Ultimately, this happens because scies include a pre-compiled a-scie/jump binary built against musl libc instead of glibc (a-scie/jump releases for linux-x86_64 and linux-aarch64 are always compiled with musl libc). To find the nce cache, a-scie/jump uses the `dirs` lib to look up the home directory by first checking for the `HOME` env var, and falling back to querying libc. This falls over because musl linux does not support NSS, so the fallback to musl libc `getpwuid_r` calls always fail for accounts provided by NSS.

If the `SCIE_BASE` env var was set, then a-scie/jump would not need to look up the home directory, but that still would not help without actually preserving the env vars when running the scie. So, we need to make sure at least `HOME` and any `SCIE_*` vars get passed to any subprocess that runs a scie. This PR just passes all of env vars, which aligns the two `PANTS_BOOTSTRAP_VERSION=report pants` calls so they are doing the same thing.