### PR TITLE
Run Python in isolated mode.

### DIFF
--- a/package/scie-pants.toml
+++ b/package/scie-pants.toml
@@ -155,6 +155,7 @@ name = "update"
 description = "Update scie-pants."
 exe = "#{cpython39:python}"
 args = [
+    "-I",
     "{tools.pex}",
     "update-scie-pants",
     "--ptex-path",
@@ -184,6 +185,7 @@ name = "scie-pants-info"
 description = "Records information about the current scie-pants binary."
 exe = "#{cpython39:python}"
 args = [
+    "-I",
     "{tools.pex}",
     "record-scie-pants-info",
     "--base-dir",
@@ -205,6 +207,7 @@ name = "configure"
 description = "Prompts the user for missing Pants configuration if needed."
 exe = "#{cpython39:python}"
 args = [
+    "-I",
     "{tools.pex}",
     "configure-pants",
     "--ptex-path",

--- a/tools/src/scie_pants/install_pants.py
+++ b/tools/src/scie_pants/install_pants.py
@@ -50,6 +50,7 @@ def install_pants_from_req(
     subprocess.run(
         args=[
             sys.executable,
+            "-I",
             "-m",
             "venv",
             "--clear",
@@ -94,6 +95,7 @@ def install_pants_from_pex(
             pants_venv_result = subprocess.run(
                 args=[
                     sys.executable,
+                    "-I",
                     pants_pex.name,
                     "venv",
                     "--prompt",


### PR DESCRIPTION
This fixes subtle hermeticity issues. 

One example seen in the wild was: users have an .env file
(set up for them in a codespace, so they may not be aware of it)
that points PYTHONPATH to a preconfigured venv's site-packages.
Then scie-pants's python3.9 attempts to load code from those
site-packages instead of its own.