### PR TITLE
Pass GITHUB_TOKEN through when packaging for release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,15 @@ jobs:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
       - name: Package scie-pants ${{ needs.determine-tag.outputs.release-tag }} binary
         if: ${{ matrix.os != 'ubuntu-22.04' && matrix.name != 'linux-arm64' }}
+        env:
+          # So we can download PBS releases without hitting github API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo run -p package -- --dest-dir dist/ scie
       - name: Package scie-pants ${{ needs.determine-tag.outputs.release-tag }} binary
         if: ${{ matrix.os == 'ubuntu-22.04' || matrix.name == 'linux-arm64' }}
+        env:
+          # So we can download PBS releases without hitting github API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cargo run -p package -- --dest-dir dist/ tools
           docker run --rm \


### PR DESCRIPTION
To avoid 403 errors on the Github API.