### PR TITLE
Using GitHub runners and removing Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
+    cooldown:
+      default-days: 7
     directory: "/"
     groups:
       rust-deps:
@@ -13,6 +15,8 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/"
     groups:
       gha-deps:

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,2 +1,0 @@
-# reuse the same runner configuration as the main Pants repo
-_extends: pants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,17 @@ jobs:
     steps:
       - name: Noop
         run: "true"
+
+      # TODO: This is just a temporary thing for debugging
+      - name: Fetch rate_limit JSON
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -s -H "Authorization: token $GITHUB_TOKEN" \
+                   -H "Accept: application/vnd.github+json" \
+                   https://api.github.com/rate_limit \
+            | jq .
+
   ci:
     name: (${{ matrix.name }}) CI
     needs: org-check
@@ -34,8 +45,8 @@ jobs:
           - os: ubuntu-22.04
             name: ubuntu-22.04
 
-          - os: [runs-on, runner=4cpu-linux-arm64, image=ubuntu22-full-arm64-python3.7-3.13, "run-id=${{ github.run_id }}"]
-            name: linux-arm64
+          - os: ubuntu-22.04-arm
+            name: ubuntu-22.04-arm
 
           - os: macos-14
             name: macos-14-arm64
@@ -49,14 +60,18 @@ jobs:
       SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
+
       - name: Check Formatting
         run: |
           rustup toolchain add nightly -c rustfmt
           cargo +nightly fmt --check --all
+
       - name: Lint
         run: cargo clippy --locked --all
+
       - name: Unit Tests
         run: cargo test --all
+
       - name: Setup Python 3.9, 3.10, 3.11 (Ubuntu only)
         if: ${{ matrix.os == 'ubuntu-22.04' }}
         uses: actions/setup-python@v6
@@ -65,12 +80,14 @@ jobs:
             3.9
             3.10
             3.11
+
       - name: Compute cache key
         id: build_it_cache_key
         run: |
           # The caches include venvs which have absolute links to Python binaries, so our system
           # should be resilient to this (see `test_pants_source_mode` in `test.rs`).
           echo "cache_key=${{ matrix.os }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
+
       - name: Cache Build and IT Artifacts
         uses: actions/cache@v5
         with:
@@ -80,47 +97,41 @@ jobs:
       # required for the PANTS_SOURCE tests, which build a version of Pants that requires an external protoc
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        if: ${{ matrix.os == 'macos-14' || matrix.os == 'ubuntu-22.04' || matrix.name == 'linux-arm64' }}
+        if: ${{ matrix.os != 'windows-2022' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 23.x
 
-      - name: Build, Package & Integration Tests (MacOS)
-        if: ${{ matrix.os == 'macos-14'}}
+      - name: Build, Package & Integration Tests
+        if: ${{ matrix.os != 'windows-2022'}}
         env:
           # Tests that scrape the github API may need this.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # TODO(John Sirois): Kill --tools-pex-mismatch-warn:
-          #   https://github.com/pantsbuild/scie-pants/issues/2
-          #
-          # N.B.: Our self-hosted runners do not clean the work directory between runs like the
-          # GitHub hosted runners do; as such, the ~/.cache/pants, etc sticks around. This exposes
-          # a bug in Pants / Pex reproducibility when building PEXes where the
-          # PEX_ROOT/installed_wheels that get packaged up into a PEX may (or may not) contain
-          # bytecode if the particular wheel was ever run against in the past. This leads to varying
-          # final PEX content.
-          #
-          cargo run -p package -- test --check --tools-pex-mismatch-warn
-      - name: Build, Package & Integration Tests (Ubuntu)
-        if: ${{ matrix.os == 'ubuntu-22.04' || matrix.name == 'linux-arm64' }}
-        env:
-          # Tests that scrape the github API may need this.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cargo run -p package -- --dest-dir dist/ tools
-          docker run --rm \
-            -v $PWD:/code \
-            -w /code \
-            rust:1.94.0-alpine3.23 \
-              sh -c '
-                apk add cmake make musl-dev perl && \
-                cargo run -p package -- --dest-dir dist/ scie-pants
-              '
-          echo
-          echo "Running under: $(uname -a)"
-          echo
           cargo run -p package -- test \
-            --tools-pex dist/tools.pex --scie-pants dist/scie-pants \
             --check \
             --tools-pex-mismatch-warn
+
+      # TODO: Disabling to see what happens
+      # - name: Build, Package & Integration Tests (Ubuntu)
+      #   if: ${{ matrix.os == 'ubuntu-22.04' || matrix.name == 'ubuntu-22.04-arm' }}
+      #   env:
+      #     # Tests that scrape the github API may need this.
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     cargo run -p package -- --dest-dir dist/ tools
+      #     docker run --rm \
+      #       -v $PWD:/code \
+      #       -w /code \
+      #       rust:1.94.0-alpine3.23 \
+      #         sh -c '
+      #           apk add cmake make musl-dev perl && \
+      #           cargo run -p package -- --dest-dir dist/ scie-pants
+      #         '
+      #     echo
+      #     echo "Running under: $(uname -a)"
+      #     echo
+      #     cargo run -p package -- test \
+      #       --tools-pex dist/tools.pex --scie-pants dist/scie-pants \
+      #       --check \
+      #       --tools-pex-mismatch-warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ on:
     outputs:
       artifact-name:
         description: The name of the uploaded artifacts
-        value: ${{ jobs.build.outputs.artifact-name }}
+        value: ${{ jobs.ci.outputs.artifact-name }}
       artifact-path:
         description: The path of the uploaded artifacts
-        value: ${{ jobs.build.outputs.artifact-path }}
+        value: ${{ jobs.ci.outputs.artifact-path }}
 
 concurrency:
   group: CI-${{ github.ref }}
@@ -123,8 +123,7 @@ jobs:
           echo "artifact-path=dist/scie-pants-*" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts
-        id: upload-artifact
-        if: ${{ github.event_name == 'workflow_dispatch' && matrix.name != 'windows-2022-x64' }}
+        if: ${{ matrix.name != 'windows-2022-x64' }}
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.package.outputs.artifact-name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     branches:
@@ -6,16 +7,27 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: The name of the uploaded artifacts
+        value: ${{ jobs.build.outputs.artifact-name }}
+      artifact-path:
+        description: The path of the uploaded artifacts
+        value: ${{ jobs.build.outputs.artifact-path }}
 
-defaults:
-  run:
-    shell: bash
 concurrency:
   group: CI-${{ github.ref }}
   # Queue on all branches and tags, but only cancel overlapping PR burns.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' || !startsWith(github.ref, 'refs/tags/') }}
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
+
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -25,36 +37,26 @@ jobs:
       - name: Noop
         run: "true"
 
-      # TODO: This is just a temporary thing for debugging
-      - name: Fetch rate_limit JSON
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl -s -H "Authorization: token $GITHUB_TOKEN" \
-                   -H "Accept: application/vnd.github+json" \
-                   https://api.github.com/rate_limit \
-            | jq .
-
   ci:
     name: (${{ matrix.name }}) CI
     needs: org-check
     runs-on: ${{ matrix.os }}
+    env:
+      PY: python3.11
+      SCIE_PANTS_DEV_CACHE: .scie_pants_dev_cache
+      SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}    
     strategy:
       matrix:
         include:
           - os: macos-14
             name: macos-14-arm64
           - os: ubuntu-22.04
-            name: ubuntu-22.04
+            name: ubuntu-22.04-x64
           - os: ubuntu-22.04-arm
-            name: ubuntu-22.04-arm
+            name: ubuntu-22.04-arm64
           - os: windows-2022
-            name: windows-2022
+            name: windows-2022-x64
 
-    env:
-      PY: python3.11
-      SCIE_PANTS_DEV_CACHE: .scie_pants_dev_cache
-      SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -69,8 +71,7 @@ jobs:
       - name: Unit Tests
         run: cargo test --all
 
-      - name: Setup Python 3.9, 3.10, 3.11 (Ubuntu only)
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+      - name: Setup Python 3.9, 3.10, 3.11
         uses: actions/setup-python@v6
         with:
           python-version: |-
@@ -83,7 +84,7 @@ jobs:
         run: |
           # The caches include venvs which have absolute links to Python binaries, so our system
           # should be resilient to this (see `test_pants_source_mode` in `test.rs`).
-          echo "cache_key=${{ matrix.os }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
+          echo "cache_key=${{ matrix.name }}-scie-pants-v7-$(which python)" | tee -a "$GITHUB_OUTPUT"
 
       - name: Cache Build and IT Artifacts
         uses: actions/cache@v5
@@ -94,13 +95,13 @@ jobs:
       # required for the PANTS_SOURCE tests, which build a version of Pants that requires an external protoc
       - name: Install Protoc
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-        if: ${{ matrix.os != 'windows-2022' }}
+        if: ${{ matrix.name != 'windows-2022-x64' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 23.x
 
-      - name: Build, Package & Integration Tests
-        if: ${{ matrix.os != 'windows-2022'}}
+      - name: Run Integration Tests
+        if: ${{ matrix.name != 'windows-2022-x64'}}
         env:
           # Tests that scrape the github API may need this.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,26 +110,23 @@ jobs:
             --check \
             --tools-pex-mismatch-warn
 
-      # TODO: Disabling to see what happens
-      # - name: Build, Package & Integration Tests (Ubuntu)
-      #   if: ${{ matrix.os == 'ubuntu-22.04' || matrix.name == 'ubuntu-22.04-arm' }}
-      #   env:
-      #     # Tests that scrape the github API may need this.
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     cargo run -p package -- --dest-dir dist/ tools
-      #     docker run --rm \
-      #       -v $PWD:/code \
-      #       -w /code \
-      #       rust:1.94.0-alpine3.23 \
-      #         sh -c '
-      #           apk add cmake make musl-dev perl && \
-      #           cargo run -p package -- --dest-dir dist/ scie-pants
-      #         '
-      #     echo
-      #     echo "Running under: $(uname -a)"
-      #     echo
-      #     cargo run -p package -- test \
-      #       --tools-pex dist/tools.pex --scie-pants dist/scie-pants \
-      #       --check \
-      #       --tools-pex-mismatch-warn
+      - name: Package scie-pants ${{ matrix.name }} binary
+        id: package
+        if: ${{ matrix.name != 'windows-2022-x64' }}
+        env:
+          # So we can download PBS releases without hitting github API rate limits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo run -p package -- --dest-dir dist/ scie
+
+          echo "artifact-name=zipped-scie-pants-${{ matrix.name }}" >> "$GITHUB_OUTPUT"
+          echo "artifact-path=dist/scie-pants-*" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        id: upload-artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && matrix.name != 'windows-2022-x64' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.package.outputs.artifact-name }}
+          path: ${{ steps.package.outputs.artifact-path }}
+          retention-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
-            name: ubuntu-22.04
-
-          - os: ubuntu-22.04-arm
-            name: ubuntu-22.04-arm
-
           - os: macos-14
             name: macos-14-arm64
-
+          - os: ubuntu-22.04
+            name: ubuntu-22.04
+          - os: ubuntu-22.04-arm
+            name: ubuntu-22.04-arm
           - os: windows-2022
             name: windows-2022
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ on:
         type: boolean
         default: false
         required: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -57,131 +62,133 @@ jobs:
             exit 1
           fi
 
-  github-release:
-    name: (${{ matrix.name }}) Create Github Release
+  run-ci:
     needs: determine-tag
+    uses: ./.github/workflows/ci.yml
+
+  github-release:
+    name: Create Github Release
+    needs: 
+      - determine-tag
+      - run-ci
+    runs-on: ubuntu-latest
     environment: Release
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: macos-14
-            name: macos-14-arm64
-          - os: ubuntu-22.04
-            name: ubuntu-22.04
-          - os: ubuntu-22.04-arm
-            name: ubuntu-22.04-arm
+    permissions:
+      id-token: write
+      attestations: write
+      contents: write
 
     steps:
-      - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
+      - name: Sparse checkout (so 'gh' will work)
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.determine-tag.outputs.release-tag }}
+          sparse-checkout: |
+            .
 
-      - name: Package scie-pants ${{ needs.determine-tag.outputs.release-tag }} binary
-        if: ${{ matrix.os != 'windows-2022' }}
-        env:
-          # So we can download PBS releases without hitting github API rate limits.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: cargo run -p package -- --dest-dir dist/ scie
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          merge-multiple: true
+          path: dist/
 
-      # Build up a draft release with the artifacts from each of these jobs:
-      - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
-        # Need to pull in https://github.com/softprops/action-gh-release/pull/316 to work-around
-        # double-release-creation that happens when attempting to update a draft release to
-        # not-draft.
-        uses: huonw/action-gh-release@998f80d5380609557d7464b01d59a10d845600a0 # v2.0.9 (v2) + https://github.com/softprops/action-gh-release/pull/316
+      - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create \
+            "${{ needs.determine-tag.outputs.release-tag }}" \
+            dist/scie-pants-* \
+            --title "scie-pants ${{ needs.determine-tag.outputs.release-version }}" \
+            --fail-on-no-commits \
+            --generate-notes \
+            --discussion-category "Announcements"
+      
+      - name: Generate ${{ needs.determine-tag.outputs.release-version }} build provenance attestations
+        uses: actions/attest@v4
         with:
-          tag_name: ${{ needs.determine-tag.outputs.release-tag }}
-          name: scie-pants ${{ needs.determine-tag.outputs.release-version }}
-          draft: true
-          # placeholder body to help someone track down why a release is still in draft:
-          body: "Release job in progress: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          files: dist/scie-pants-*
-          fail_on_unmatched_files: true
+          subject-path: dist/scie-pants-*
 
-  publish-announce-release:
-    name: Publish and Announce Release
-    needs:
-      - determine-tag
-      - github-release
-    runs-on: ubuntu-22.04
+  # TODO
+  # publish-announce-release:
+  #   name: Publish and Announce Release
+  #   needs:
+  #     - determine-tag
+  #     - github-release
+  #   runs-on: ubuntu-latest
 
-    steps:
-      # Now, do the human-facing prep on the release (changelog etc.), and publish it
-      - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.determine-tag.outputs.release-tag }}
+  #   steps:
+  #     # Now, do the human-facing prep on the release (changelog etc.), and publish it
+  #     - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
+  #       uses: actions/checkout@v6
+  #       with:
+  #         ref: ${{ needs.determine-tag.outputs.release-tag }}
 
-      - name: Prepare Changelog
-        id: prepare-changelog
-        uses: a-scie/actions/changelog@v1.6
-        with:
-          changelog-file: ${{ github.workspace }}/CHANGES.md
-          version: ${{ needs.determine-tag.outputs.release-version }}
-          setup-python: true
+  #     - name: Prepare Changelog
+  #       id: prepare-changelog
+  #       uses: a-scie/actions/changelog@v1.6
+  #       with:
+  #         changelog-file: ${{ github.workspace }}/CHANGES.md
+  #         version: ${{ needs.determine-tag.outputs.release-version }}
+  #         setup-python: true
 
-      - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
-        # See above for discussion:
-        uses: huonw/action-gh-release@998f80d5380609557d7464b01d59a10d845600a0 # v2.0.9 (v2) + https://github.com/softprops/action-gh-release/pull/316
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.determine-tag.outputs.release-tag }}
-          name: scie-pants ${{ needs.determine-tag.outputs.release-version }}
-          body_path: ${{ steps.prepare-changelog.outputs.changelog-file }}
-          draft: false
-          prerelease: ${{ needs.determine-tag.outputs.prerelease }}
-          discussion_category_name: Announcements
+  #     - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
+  #       # See above for discussion:
+  #       uses: huonw/action-gh-release@998f80d5380609557d7464b01d59a10d845600a0 # v2.0.9 (v2) + https://github.com/softprops/action-gh-release/pull/316
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag_name: ${{ needs.determine-tag.outputs.release-tag }}
+  #         name: scie-pants ${{ needs.determine-tag.outputs.release-version }}
+  #         body_path: ${{ steps.prepare-changelog.outputs.changelog-file }}
+  #         draft: false
+  #         prerelease: ${{ needs.determine-tag.outputs.prerelease }}
+  #         discussion_category_name: Announcements
 
-      # Announce the release! Yay
-      - name: Post Release Announcement to Pants Slack `#announce`
-        if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
-        id: slack
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          channel-id: "C18RRR4JK"
-          # N.B.: You can muck with the JSON blob and see the results rendered here:
-          #  https://app.slack.com/block-kit-builder
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "The `pants` launcher binary (scie-pants) ${{ needs.determine-tag.outputs.release-tag }} is released:\n* https://github.com/pantsbuild/scie-pants/releases/tag/${{ needs.determine-tag.outputs.release-tag }}\n* https://www.pantsbuild.org/docs/installation"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  #     # Announce the release! Yay
+  #     - name: Post Release Announcement to Pants Slack `#announce`
+  #       if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
+  #       id: slack
+  #       uses: slackapi/slack-github-action@v1.23.0
+  #       with:
+  #         channel-id: "C18RRR4JK"
+  #         # N.B.: You can muck with the JSON blob and see the results rendered here:
+  #         #  https://app.slack.com/block-kit-builder
+  #         payload: |
+  #           {
+  #             "blocks": [
+  #               {
+  #                 "type": "section",
+  #                 "text": {
+  #                   "type": "mrkdwn",
+  #                   "text": "The `pants` launcher binary (scie-pants) ${{ needs.determine-tag.outputs.release-tag }} is released:\n* https://github.com/pantsbuild/scie-pants/releases/tag/${{ needs.determine-tag.outputs.release-tag }}\n* https://www.pantsbuild.org/docs/installation"
+  #                 }
+  #               }
+  #             ]
+  #           }
+  #       env:
+  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
-  update-homebrew-tap:
-    name: Update pantsbuild/homebrew-tap
-    needs:
-      - determine-tag
-      - github-release
-    runs-on: ubuntu-22.04
+  # update-homebrew-tap:
+  #   name: Update pantsbuild/homebrew-tap
+  #   needs:
+  #     - determine-tag
+  #     - github-release
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Bump `scie-pants` version in Casks/pants.rb to ${{ needs.determine-tag.outputs.release-tag }}
-        if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.TAP_TOKEN }}
-          # Docs: https://octokit.github.io/rest.js/v19#actions-create-workflow-dispatch
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: 'pantsbuild',
-              repo: 'homebrew-tap',
-              workflow_id: 'release.yml',
-              ref: 'main',
-              inputs: {
-                tag: '${{ needs.determine-tag.outputs.release-tag }}'
-              }
-            })
+  #   steps:
+  #     - name: Bump `scie-pants` version in Casks/pants.rb to ${{ needs.determine-tag.outputs.release-tag }}
+  #       if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
+  #       uses: actions/github-script@v8
+  #       with:
+  #         github-token: ${{ secrets.TAP_TOKEN }}
+  #         # Docs: https://octokit.github.io/rest.js/v19#actions-create-workflow-dispatch
+  #         script: |
+  #           await github.rest.actions.createWorkflowDispatch({
+  #             owner: 'pantsbuild',
+  #             repo: 'homebrew-tap',
+  #             workflow_id: 'release.yml',
+  #             ref: 'main',
+  #             inputs: {
+  #               tag: '${{ needs.determine-tag.outputs.release-tag }}'
+  #             }
+  #           })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
     steps:
       # Now, do the human-facing prep on the release (changelog etc.), and publish it
       - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,14 @@
 name: Release
 on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
     inputs:
       tag:
-        description: The tag to manually run a deploy for. (example tag `v1.2.3`)
+        description: The scie-pants release version (i.e. `v1.2.3`)
         required: true
       prerelease:
         description: |
-          Is this for a prerelease?
-          (for internal testing, not announced nor published to our brew tap)
-          (example tag `v1.2.3-beta.0`)
+          Is this a pre-release?
+          These are not announced in Slack nor published to HomeBrew (i.e. `v1.2.3-beta.0`)
         type: boolean
         default: false
         required: true
@@ -28,7 +24,7 @@ jobs:
   org-check:
     name: Check GitHub Organization
     if: ${{ github.repository_owner == 'pantsbuild' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Noop
         run: "true"
@@ -36,7 +32,10 @@ jobs:
   determine-tag:
     name: Determine the release tag to operate against.
     needs: org-check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag }}
+      PRERELEASE: ${{ github.event.inputs.prerelease }}
     outputs:
       release-tag: ${{ steps.determine-tag.outputs.release-tag }}
       release-version: ${{ steps.determine-tag.outputs.release-version }}
@@ -46,14 +45,7 @@ jobs:
       - name: Determine Tag
         id: determine-tag
         run: |
-          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
-            RELEASE_TAG=${{ github.event.inputs.tag }}
-            PRERELEASE=${{ github.event.inputs.prerelease }}
-          else
-            RELEASE_TAG=${GITHUB_REF#refs/tags/}
-            PRERELEASE=false
-          fi
-          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]] || [[ "${PRERELEASE}" == true ]]; then
+          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "${PRERELEASE}" == true ]]; then
             echo "release-tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
             echo "release-version=${RELEASE_TAG#v}" >> $GITHUB_OUTPUT
             echo "prerelease=${PRERELEASE}" >> $GITHUB_OUTPUT
@@ -77,6 +69,7 @@ jobs:
       id-token: write
       attestations: write
       contents: write
+      discussions: write
 
     steps:
       - name: Sparse checkout (so 'gh' will work)
@@ -91,104 +84,88 @@ jobs:
           merge-multiple: true
           path: dist/
 
-      - name: Create release
+      - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.determine-tag.outputs.release-tag }}
+          RELEASE_VERSION: ${{ needs.determine-tag.outputs.release-version }}
+          PRERELEASE: ${{ needs.determine-tag.outputs.prerelease }}
         run: |
+          # Using Markdown headers, grab everything between the current version and subsequent (including current version title)
+          CHANGELOG_NOTES=$(sed -n "/^## ${RELEASE_VERSION}/, /^## /p" CHANGES.md | sed '$d')
+
+          PRERELEASE_FLAG=""
+          if [[ "$PRERELEASE" != "false" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
           gh release create \
-            "${{ needs.determine-tag.outputs.release-tag }}" \
+            "$RELEASE_TAG" \
             dist/scie-pants-* \
-            --title "scie-pants ${{ needs.determine-tag.outputs.release-version }}" \
+            --discussion-category "Announcements" \
             --fail-on-no-commits \
-            --generate-notes \
-            --discussion-category "Announcements"
-      
+            --notes "$CHANGELOG_NOTES" \
+            --repo pantsbuild/scie-pants \
+            --title "scie-pants $RELEASE_VERSION" \
+            $PRERELEASE_FLAG
+
       - name: Generate ${{ needs.determine-tag.outputs.release-version }} build provenance attestations
         uses: actions/attest@v4
         with:
           subject-path: dist/scie-pants-*
 
-  # TODO
-  # publish-announce-release:
-  #   name: Publish and Announce Release
-  #   needs:
-  #     - determine-tag
-  #     - github-release
-  #   runs-on: ubuntu-latest
+  publish-announce-release:
+    name: Publish and Announce Release
+    needs:
+      - determine-tag
+      - github-release
+    if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     # Now, do the human-facing prep on the release (changelog etc.), and publish it
-  #     - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
-  #       uses: actions/checkout@v6
-  #       with:
-  #         ref: ${{ needs.determine-tag.outputs.release-tag }}
+    steps:
+      - name: Sparse checkout (to get the Changelog)
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .
 
-  #     - name: Prepare Changelog
-  #       id: prepare-changelog
-  #       uses: a-scie/actions/changelog@v1.6
-  #       with:
-  #         changelog-file: ${{ github.workspace }}/CHANGES.md
-  #         version: ${{ needs.determine-tag.outputs.release-version }}
-  #         setup-python: true
+      - name: Post release announcement to Pants Slack in `#announce` channel
+        uses: slackapi/slack-github-action@v1.23.0
+        id: slack
+        env:
+          RELEASE_TAG: ${{ needs.determine-tag.outputs.release-tag }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: "C18RRR4JK"
+          # N.B.: You can muck with the JSON blob and see the results rendered here:
+          #  https://app.slack.com/block-kit-builder
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "The `pants` launcher binary (scie-pants) $RELEASE_TAG is released:\n* https://github.com/pantsbuild/scie-pants/releases/tag/${RELEASE_TAG}\n* https://www.pantsbuild.org/docs/installation"
+                  }
+                }
+              ]
+            }
 
-  #     - name: Publish ${{ needs.determine-tag.outputs.release-tag }} Release
-  #       # See above for discussion:
-  #       uses: huonw/action-gh-release@998f80d5380609557d7464b01d59a10d845600a0 # v2.0.9 (v2) + https://github.com/softprops/action-gh-release/pull/316
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       with:
-  #         tag_name: ${{ needs.determine-tag.outputs.release-tag }}
-  #         name: scie-pants ${{ needs.determine-tag.outputs.release-version }}
-  #         body_path: ${{ steps.prepare-changelog.outputs.changelog-file }}
-  #         draft: false
-  #         prerelease: ${{ needs.determine-tag.outputs.prerelease }}
-  #         discussion_category_name: Announcements
+  update-homebrew-tap:
+    name: Update pantsbuild/homebrew-tap
+    needs:
+      - determine-tag
+      - github-release
+    if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
+    runs-on: ubuntu-latest
 
-  #     # Announce the release! Yay
-  #     - name: Post Release Announcement to Pants Slack `#announce`
-  #       if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
-  #       id: slack
-  #       uses: slackapi/slack-github-action@v1.23.0
-  #       with:
-  #         channel-id: "C18RRR4JK"
-  #         # N.B.: You can muck with the JSON blob and see the results rendered here:
-  #         #  https://app.slack.com/block-kit-builder
-  #         payload: |
-  #           {
-  #             "blocks": [
-  #               {
-  #                 "type": "section",
-  #                 "text": {
-  #                   "type": "mrkdwn",
-  #                   "text": "The `pants` launcher binary (scie-pants) ${{ needs.determine-tag.outputs.release-tag }} is released:\n* https://github.com/pantsbuild/scie-pants/releases/tag/${{ needs.determine-tag.outputs.release-tag }}\n* https://www.pantsbuild.org/docs/installation"
-  #                 }
-  #               }
-  #             ]
-  #           }
-  #       env:
-  #         SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  # update-homebrew-tap:
-  #   name: Update pantsbuild/homebrew-tap
-  #   needs:
-  #     - determine-tag
-  #     - github-release
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Bump `scie-pants` version in Casks/pants.rb to ${{ needs.determine-tag.outputs.release-tag }}
-  #       if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}
-  #       uses: actions/github-script@v8
-  #       with:
-  #         github-token: ${{ secrets.TAP_TOKEN }}
-  #         # Docs: https://octokit.github.io/rest.js/v19#actions-create-workflow-dispatch
-  #         script: |
-  #           await github.rest.actions.createWorkflowDispatch({
-  #             owner: 'pantsbuild',
-  #             repo: 'homebrew-tap',
-  #             workflow_id: 'release.yml',
-  #             ref: 'main',
-  #             inputs: {
-  #               tag: '${{ needs.determine-tag.outputs.release-tag }}'
-  #             }
-  #           })
+    steps:
+      - name: Bump `scie-pants` version in Casks/pants.rb to ${{ needs.determine-tag.outputs.release-tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.TAP_TOKEN }}
+          RELEASE_TAG: ${{ needs.determine-tag.outputs.release-tag }}
+        run: |
+          gh workflow run "release.yml" \
+            --raw-field "tag=$RELEASE_TAG" \
+            --repo pantsbuild/homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
         required: true
 env:
   CARGO_TERM_COLOR: always
+
 jobs:
   org-check:
     name: Check GitHub Organization
@@ -26,6 +27,7 @@ jobs:
     steps:
       - name: Noop
         run: "true"
+
   determine-tag:
     name: Determine the release tag to operate against.
     needs: org-check
@@ -34,6 +36,7 @@ jobs:
       release-tag: ${{ steps.determine-tag.outputs.release-tag }}
       release-version: ${{ steps.determine-tag.outputs.release-version }}
       prerelease: ${{ steps.determine-tag.outputs.prerelease }}
+
     steps:
       - name: Determine Tag
         id: determine-tag
@@ -53,50 +56,34 @@ jobs:
             echo "::error::Release tag '${RELEASE_TAG}' must match 'v\d+.\d+.\d+' when not doing a pre-release."
             exit 1
           fi
+
   github-release:
     name: (${{ matrix.name }}) Create Github Release
     needs: determine-tag
+    environment: Release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
-            name: ubuntu-22.04
-
-          - os: [runs-on, runner=4cpu-linux-arm64, image=ubuntu22-full-arm64-python3.7-3.13, "run-id=${{ github.run_id }}"]
-            name: linux-arm64
-
           - os: macos-14
             name: macos-14-arm64
-    environment: Release
+          - os: ubuntu-22.04
+            name: ubuntu-22.04
+          - os: ubuntu-22.04-arm
+            name: ubuntu-22.04-arm
+
     steps:
       - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.determine-tag.outputs.release-tag }}
+
       - name: Package scie-pants ${{ needs.determine-tag.outputs.release-tag }} binary
-        if: ${{ matrix.os != 'ubuntu-22.04' && matrix.name != 'linux-arm64' }}
+        if: ${{ matrix.os != 'windows-2022' }}
         env:
           # So we can download PBS releases without hitting github API rate limits.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cargo run -p package -- --dest-dir dist/ scie
-      - name: Package scie-pants ${{ needs.determine-tag.outputs.release-tag }} binary
-        if: ${{ matrix.os == 'ubuntu-22.04' || matrix.name == 'linux-arm64' }}
-        env:
-          # So we can download PBS releases without hitting github API rate limits.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cargo run -p package -- --dest-dir dist/ tools
-          docker run --rm \
-            -v $PWD:/code \
-            -w /code \
-            rust:1.94.0-alpine3.23 \
-              sh -c '
-                apk add cmake make musl-dev perl && \
-                cargo run -p package -- --dest-dir dist/ scie-pants
-              '
-          cargo run -p package -- --dest-dir dist/ scie \
-            --scie-pants dist/scie-pants --tools-pex dist/tools.pex
 
       # Build up a draft release with the artifacts from each of these jobs:
       - name: Create ${{ needs.determine-tag.outputs.release-tag }} Release
@@ -121,6 +108,7 @@ jobs:
       - determine-tag
       - github-release
     runs-on: ubuntu-22.04
+
     steps:
       # Now, do the human-facing prep on the release (changelog etc.), and publish it
       - name: Checkout scie-pants ${{ needs.determine-tag.outputs.release-tag }}
@@ -172,12 +160,14 @@ jobs:
             }
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
   update-homebrew-tap:
     name: Update pantsbuild/homebrew-tap
     needs:
       - determine-tag
       - github-release
     runs-on: ubuntu-22.04
+
     steps:
       - name: Bump `scie-pants` version in Casks/pants.rb to ${{ needs.determine-tag.outputs.release-tag }}
         if: ${{ needs.determine-tag.outputs.prerelease != 'true' }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,47 +2,38 @@
 
 ## Preparation
 
-### Version Bump and Changelog
-
 1. Bump the version in [`Cargo.toml`](Cargo.toml).
-2. Run `cargo run -p package -- test` to update [`Cargo.lock`](Cargo.lock) with the new version and
-   as a sanity check on the state of the project.
+2. Run `cargo run -p package -- test` to update [`Cargo.lock`](Cargo.lock) with the new version and as a sanity check on the state of the project.
 3. Update [`CHANGES.md`](CHANGES.md) with any changes that are likely to be useful to consumers.
 4. Open a PR with these changes and land it on https://github.com/pantsbuild/scie-pants main.
 
 ## Release
 
-### Push Release Tag
+The release process is driven by GitHub Actions workflows.
 
-Sync a local branch with https://github.com/pantsbuild/scie-pants main and confirm it has the
-version bump and changelog update as the tip commit:
+On success, a new release is published to https://github.com/pantsbuild/scie-pants/releases with Linux and Mac binaries. Additionally, a new discussion announcement will be opened in https://github.com/pantsbuild/scie-pants/discussions, a Slack notification will be sent in `#announce`, and the [HomeBrew tap](https://github.com/pantsbuild/homebrew-tap) will get a version bump. 
 
-```
-$ git log --stat -1
-commit bb62b599ffb84189b2729cad77177f0146f364d9 (HEAD)
-Author: John Sirois <john.sirois@gmail.com>
-Date:   Sat Dec 17 10:48:31 2022 -0800
+Once the version/CHANGES.md update (in `Preparation` above) has landed, kick off a GitHub release via the [Actions Web UI](https://github.com/pantsbuild/scie-pants/actions/workflows/release.yml), or using the `gh` cli (where `{{ A.B.C }}` is the version of interest - e.g. `0.13.2`):
 
-    Release 0.1.8.
+```bash
+gh workflow run "release.yml" \
+   --raw-field "tag=v{{ A.B.C }}" \
+   --repo pantsbuild/scie-pants
 
-    Upgrade to `scie-jump` 0.7.1 to avoid `SCIE_BOOT=update scie-pants`
-    inifinite loop.
+# ✓ Created workflow_dispatch event for release.yml at main
+# https://github.com/pantsbuild/scie-pants/actions/runs/XYZ
 
- CHANGES.md          | 2 +-
- Cargo.lock          | 2 +-
- Cargo.toml          | 2 +-
- package/src/main.rs | 2 +-
- 4 files changed, 4 insertions(+), 4 deletions(-)
+# To see the created workflow run, try: gh run view XYZ
+# To see runs for this workflow, try: gh run list --workflow="release.yml"
 ```
 
-Tag the release as `v<version>` and push the tag to https://github.com/pantsbuild/scie-pants main:
+Alternatively, a pre-release can be kicked off via:
 
+```bash
+gh workflow run "release.yml" \
+   --raw-field "tag=v0.13.2-beta.1" \
+   --raw-field "prerelease=true" \
+   --repo pantsbuild/scie-pants 
 ```
-$ git tag --sign -am 'Release 0.1.9' v0.1.9
-$ git push --tags https://github.com/pantsbuild/scie-pants HEAD:main
-```
 
-The release is automated and will create a GitHub Release page at
-[https://github.com/pantsbuild/scie-pants/releases/tag/v&lt;version&gt;](
-https://github.com/pantsbuild/scie-pants) with binaries for Linux & Mac.
-
+The only substantial difference in declaring a pre-release is that the `tag` field skips versioning checks (i.e. any name is fine) and there will be no Slack/HomeBrew announcements or updates for pre-release builds.


### PR DESCRIPTION
This PR consolidates the CI and release process, such that "release" now calls "ci" for output and all compilation/testing occurs on a single workflow action, rather than partial duplication.

As well, we only use GitHub Actions runners (i.e. `linux-arm`) so we can remove some temporary workarounds that were in-place for persistent workers, and remove the `runsOn` file.

Several external re-usable actions have been replaced with either the `gh` cli command, or more limited bash scripts.

A notable change is the removal of any `push`-based building for releases, in favour of workflow dispatches, directly based off `main`. This removes the need for any local tag signing.

### --- Original in-progress description ---

This is a mix of several different changes, which I'm playing with on my own fork (https://github.com/sureshjoshi/scie-pants/actions/runs/24041142971).

I'd like to consolidate the GHA and try to not have special cases if we can avoid it. I'd also like to avoid mixing Docker steps with the rest.

So, this PR attempts to do all that. I have a matrix without per-OS variants. I haven't tried running these yet, but on my fork, CI passes, and release is .... weird: https://github.com/sureshjoshi/scie-pants/deployments

I have some follow-up improvements to make, to not use unnecessary 3rd party actions to do relatively trivial things like downloading protoc or creating a GH release. Hopefully this will help surface errors

This is all that's needed on a non-matrix build (https://sureshjoshi.com/development/github-actions-immutable-release-provenance#release-workflow):

```bash
    - name: Generate
      env:
        GH_TOKEN: ${{ github.token }}
      run: |
        gh release create \
          ${{ needs.determine-version.outputs.release-version }} \
          ${{ needs.run-ci.outputs.artifact-path }} \
          --fail-on-no-commits \
          --generate-notes \
          --repo sureshjoshi/scratch
    
    - name: Generate ${{ needs.determine-version.outputs.release-version }} build provenance attestations
      uses: actions/attest-build-provenance@v3
      with:
        subject-path: ${{ needs.run-ci.outputs.artifact-path }}
```

For a matrix build, I think I just need to run the matrix, create a step that relies on the output of the matrix, and create the release there...

Note: This PR should be the thing that lets me test the CI changes... Just putting reviewers on in case anyone is more familiar with the quirks of action runs.