### PR TITLE
Added cargo and zizmor audit workflows

### DIFF
--- a/.github/workflows/audit-cargo.yml
+++ b/.github/workflows/audit-cargo.yml
@@ -2,7 +2,7 @@ name: Scheduled cargo audit
 
 on:
   schedule:
-  - cron: 11 8 * * *
+  - cron: 11 8 * * *  # 8:11am
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/audit-cargo.yml
+++ b/.github/workflows/audit-cargo.yml
@@ -1,0 +1,23 @@
+name: Scheduled cargo audit
+
+on:
+  schedule:
+  - cron: 11 8 * * *
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  cargo-audit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Cargo audit (for security vulnerabilities)
+      run: |
+        cargo install cargo-audit --locked
+        cargo audit

--- a/.github/workflows/audit-zizmor.yml
+++ b/.github/workflows/audit-zizmor.yml
@@ -1,0 +1,27 @@
+name: Scheduled zizmor audit
+
+on:
+  schedule:
+  - cron: 11 8 * * *
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  zizmor-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        sparse-checkout: |
+            .
+            .github
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/audit-zizmor.yml
+++ b/.github/workflows/audit-zizmor.yml
@@ -2,7 +2,7 @@ name: Scheduled zizmor audit
 
 on:
   schedule:
-  - cron: 11 8 * * *
+  - cron: 21 8 * * *  # 8:21am
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
Zizmor checks GHA workflows and updates to "Security and quality" tab.
Cargo audit's action is out of date, so just running it and taking the error.