### PR TITLE
Use musl for default compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,27 @@ jobs:
         include:
           - os: macos-14
             name: macos-14-arm64
+            target: aarch64-apple-darwin
+
+          # - os: ubuntu-22.04
+          #   name: ubuntu-22.04-x64-gnu
+          #   target: x86_64-unknown-linux-gnu
+
           - os: ubuntu-22.04
             name: ubuntu-22.04-x64
+            target: x86_64-unknown-linux-musl
+
+          # - os: ubuntu-22.04-arm
+          #   name: ubuntu-22.04-arm64-gnu
+          #   target: aarch64-unknown-linux-gnu
+
           - os: ubuntu-22.04-arm
             name: ubuntu-22.04-arm64
+            target: aarch64-unknown-linux-musl
+
           - os: windows-2022
             name: windows-2022-x64
+            target: x86_64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v6
@@ -100,13 +115,21 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 23.x
 
+      - name: Install platform target
+        if: ${{ matrix.name != 'windows-2022-x64'}}
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          rustup target add $TARGET
+
       - name: Run Integration Tests
         if: ${{ matrix.name != 'windows-2022-x64'}}
         env:
           # Tests that scrape the github API may need this.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ matrix.target }}
         run: |
-          cargo run -p package -- test \
+          cargo run -p package -- --target $TARGET test \
             --check \
             --tools-pex-mismatch-warn
 
@@ -116,10 +139,12 @@ jobs:
         env:
           # So we can download PBS releases without hitting github API rate limits.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NAME: ${{ matrix.name }}
+          TARGET: ${{ matrix.target }}
         run: |
-          cargo run -p package -- --dest-dir dist/ scie
+          cargo run -p package -- --dest-dir dist/ --target $TARGET scie
 
-          echo "artifact-name=zipped-scie-pants-${{ matrix.name }}" >> "$GITHUB_OUTPUT"
+          echo "artifact-name=zipped-scie-pants-$NAME" >> "$GITHUB_OUTPUT"
           echo "artifact-path=dist/scie-pants-*" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts


### PR DESCRIPTION
Not that it really matters, as by default, this still tries to pull the gnu python-build-standalones (there is an open issue with more info, should be a simple fix). However, for the sake of consistency, we should continue using musl for the upcoming release.

My hope here was to jump straight to #517 for cross-compilation, as seemed simple enough (and seemed to work in my testing), but I didn't have time to fiddle with the `install` vs `zigbuild` flags to get everything appearing in the same location yet.

So, here's a multi-step approach (subsequent steps in subsequent PRs):
- Default to using `musl` for builds again (this PR)
- Uncomment the `gnu` platforms in ci.yml and update the code to re-name including target information (or just re-name to the target, or whatever).
  - This requires updating our Homebrew script, and likely some of our documentation to point to the newly named filed
- Use zigbuild to cross-compile and set the target glibc version to update the OS independently of the compilation

Working compilation here:
https://github.com/sureshjoshi/scie-pants/actions/runs/24407728755